### PR TITLE
Add routing to the api

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,7 @@ COMPUTE_TYPE="int8_float16"
 NEMO_DOMAIN_TYPE="telephonic"  # Can be general, meeting or telephonic based on domain type of the audio file
 NEMO_STORAGE_PATH="nemo_storage"
 NEMO_OUTPUT_PATH="nemo_outputs"
+AUDIO_FILE_ENDPOINT=True
+AUDIO_URL_ENDPOINT=True
+YOUTUBE_ENDPOINT=True
+LIVE_ENDPOINT=False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,3 +34,8 @@ def test_config() -> None:
     assert settings.nemo_domain_type == "telephonic"
     assert settings.nemo_storage_path == "nemo_storage"
     assert settings.nemo_output_path == "nemo_outputs"
+
+    assert settings.audio_file_endpoint is True
+    assert settings.audio_url_endpoint is True
+    assert settings.youtube_endpoint is True
+    assert settings.live_endpoint is False

--- a/wordcab_transcribe/config.py
+++ b/wordcab_transcribe/config.py
@@ -41,6 +41,11 @@ class Settings:
     nemo_domain_type: str
     nemo_storage_path: str
     nemo_output_path: str
+    # API endpoints
+    audio_file_endpoint: bool
+    audio_url_endpoint: bool
+    youtube_endpoint: bool
+    live_endpoint: bool
 
     @validator("project_name", "version", "description", "api_prefix")
     def basic_parameters_must_not_be_none(
@@ -105,4 +110,8 @@ settings = Settings(
     nemo_domain_type=getenv("NEMO_DOMAIN_TYPE", "general"),
     nemo_storage_path=getenv("NEMO_STORAGE_PATH", "nemo_storage"),
     nemo_output_path=getenv("NEMO_OUTPUT_PATH", "nemo_outputs"),
+    audio_file_endpoint=getenv("AUDIO_FILE_ENDPOINT", True),
+    audio_url_endpoint=getenv("AUDIO_URL_ENDPOINT", True),
+    youtube_endpoint=getenv("YOUTUBE_ENDPOINT", True),
+    live_endpoint=getenv("LIVE_ENDPOINT", False),
 )

--- a/wordcab_transcribe/dependencies.py
+++ b/wordcab_transcribe/dependencies.py
@@ -1,0 +1,19 @@
+# Copyright 2023 The Wordcab Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dependencies for the API."""
+
+from wordcab_transcribe.service import ASRService
+
+
+asr = ASRService()

--- a/wordcab_transcribe/main.py
+++ b/wordcab_transcribe/main.py
@@ -82,7 +82,7 @@ async def home():
     return HTMLResponse(content=content, media_type="text/html")
 
 
-@app.get("/health", status_code=http_status.HTTP_200_OK, tags=["status"])
+@app.get("/healthz", status_code=http_status.HTTP_200_OK, tags=["status"])
 async def health():
     """Health check endpoint."""
     return {"status": "ok"}

--- a/wordcab_transcribe/main.py
+++ b/wordcab_transcribe/main.py
@@ -15,28 +15,15 @@
 """Main API module of the Wordcab Transcribe."""
 
 import asyncio
-from typing import Optional
 
-import aiofiles
-import shortuuid
-from fastapi import BackgroundTasks, FastAPI, File, UploadFile
-from fastapi import status as http_status
+from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from loguru import logger
 
 from wordcab_transcribe.config import settings
-from wordcab_transcribe.models import ASRResponse, DataRequest
-from wordcab_transcribe.service import ASRService
-from wordcab_transcribe.utils import (
-    convert_file_to_wav,
-    convert_timestamp,
-    delete_file,
-    download_audio_file,
-    download_file_from_youtube,
-    format_punct,
-    is_empty_string,
-    retrieve_user_platform,
-)
+from wordcab_transcribe.dependencies import asr
+from wordcab_transcribe.router.v1.endpoints import api_router
+from wordcab_transcribe.utils import retrieve_user_platform
 
 
 app = FastAPI(
@@ -46,7 +33,7 @@ app = FastAPI(
     debug=settings.debug,
 )
 
-asr = ASRService()
+app.include_router(api_router, prefix=settings.api_prefix)
 
 
 @app.on_event("startup")
@@ -92,137 +79,3 @@ async def health_check():
     </html>
     """
     return HTMLResponse(content=content, media_type="text/html")
-
-
-@app.post(
-    f"{settings.api_prefix}/audio",
-    tags=["inference"],
-    response_model=ASRResponse,
-    status_code=http_status.HTTP_200_OK,
-)
-async def inference_with_audio(
-    background_tasks: BackgroundTasks,
-    file: UploadFile = File(...),  # noqa: B008
-    data: Optional[DataRequest] = None,
-) -> ASRResponse:
-    """Inference endpoint with audio file."""
-    extension = file.filename.split(".")[-1]
-    filename = f"audio_{shortuuid.ShortUUID().random(length=32)}.{extension}"
-
-    async with aiofiles.open(filename, "wb") as f:
-        audio_bytes = await file.read()
-        await f.write(audio_bytes)
-
-    if extension != "wav":
-        filepath = await convert_file_to_wav(filename)
-        background_tasks.add_task(delete_file, filepath=filename)
-    else:
-        filepath = filename
-
-    if data is None:
-        data = DataRequest()
-    else:
-        data = DataRequest(**data.dict())
-
-    raw_utterances = await asr.process_input(filepath, data.source_lang)
-
-    timestamps_format = data.timestamps
-    utterances = [
-        {
-            "text": format_punct(utterance["text"]),
-            "start": convert_timestamp(utterance["start"], timestamps_format),
-            "end": convert_timestamp(utterance["end"], timestamps_format),
-            "speaker": int(utterance["speaker"]),
-        }
-        for utterance in raw_utterances
-        if not is_empty_string(utterance["text"])
-    ]
-
-    background_tasks.add_task(delete_file, filepath=filepath)
-
-    return ASRResponse(utterances=utterances)
-
-
-@app.post(
-    f"{settings.api_prefix}/youtube",
-    tags=["inference"],
-    response_model=ASRResponse,
-    status_code=http_status.HTTP_200_OK,
-)
-async def inference_with_youtube(
-    background_tasks: BackgroundTasks,
-    url: str,
-    data: Optional[DataRequest] = None,
-) -> ASRResponse:
-    """Inference endpoint with YouTube url."""
-    filename = f"yt_{shortuuid.ShortUUID().random(length=32)}"
-    filepath = await download_file_from_youtube(url, filename)
-
-    if data is None:
-        data = DataRequest()
-    else:
-        data = DataRequest(**data.dict())
-
-    raw_utterances = await asr.process_input(filepath, data.source_lang)
-
-    timestamps_format = data.timestamps
-    utterances = [
-        {
-            "text": format_punct(utterance["text"]),
-            "start": convert_timestamp(utterance["start"], timestamps_format),
-            "end": convert_timestamp(utterance["end"], timestamps_format),
-            "speaker": int(utterance["speaker"]),
-        }
-        for utterance in raw_utterances
-        if not is_empty_string(utterance["text"])
-    ]
-
-    background_tasks.add_task(delete_file, filepath=filepath)
-
-    return ASRResponse(utterances=utterances)
-
-
-@app.post(
-    f"{settings.api_prefix}/audio-url",
-    tags=["inference"],
-    response_model=ASRResponse,
-    status_code=http_status.HTTP_200_OK,
-)
-async def inference_with_audio_url(
-    background_tasks: BackgroundTasks,
-    url: str,
-    data: Optional[DataRequest] = None,
-) -> ASRResponse:
-    """Inference endpoint with audio url."""
-    filename = f"audio_url_{shortuuid.ShortUUID().random(length=32)}"
-    filepath = await download_audio_file(url, filename)
-    extension = filepath.split(".")[-1]
-
-    if extension != "wav":
-        filepath = await convert_file_to_wav(filepath)
-        background_tasks.add_task(delete_file, filepath=f"{filename}.{extension}")
-    else:
-        filepath = filename
-
-    if data is None:
-        data = DataRequest()
-    else:
-        data = DataRequest(**data.dict())
-
-    raw_utterances = await asr.process_input(filepath, data.source_lang)
-
-    timestamps_format = data.timestamps
-    utterances = [
-        {
-            "text": format_punct(utterance["text"]),
-            "start": convert_timestamp(utterance["start"], timestamps_format),
-            "end": convert_timestamp(utterance["end"], timestamps_format),
-            "speaker": int(utterance["speaker"]),
-        }
-        for utterance in raw_utterances
-        if not is_empty_string(utterance["text"])
-    ]
-
-    background_tasks.add_task(delete_file, filepath=filepath)
-
-    return ASRResponse(utterances=utterances)

--- a/wordcab_transcribe/main.py
+++ b/wordcab_transcribe/main.py
@@ -17,6 +17,7 @@
 import asyncio
 
 from fastapi import FastAPI
+from fastapi import status as http_status
 from fastapi.responses import HTMLResponse
 from loguru import logger
 
@@ -52,7 +53,7 @@ async def startup_event():
 
 
 @app.get("/", tags=["status"])
-async def health_check():
+async def home():
     """Health check endpoint."""
     content = f"""
     <!DOCTYPE html>
@@ -79,3 +80,9 @@ async def health_check():
     </html>
     """
     return HTMLResponse(content=content, media_type="text/html")
+
+
+@app.get("/health", status_code=http_status.HTTP_200_OK, tags=["status"])
+async def health():
+    """Health check endpoint."""
+    return {"status": "ok"}

--- a/wordcab_transcribe/router/__init__.py
+++ b/wordcab_transcribe/router/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 The Wordcab Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Routing module for the API part of the Wordcab Transcribe."""

--- a/wordcab_transcribe/router/v1/__init__.py
+++ b/wordcab_transcribe/router/v1/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 The Wordcab Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""V1 endpoints for the Wordcab Transcribe API."""

--- a/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -1,0 +1,79 @@
+# Copyright 2023 The Wordcab Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Audio file endpoint for the Wordcab Transcribe API."""
+
+from typing import Optional
+
+import aiofiles
+import shortuuid
+
+from fastapi import APIRouter, BackgroundTasks, File, UploadFile
+from fastapi import status as http_status
+
+from wordcab_transcribe.dependencies import asr
+from wordcab_transcribe.models import ASRResponse, DataRequest
+from wordcab_transcribe.utils import (
+    convert_file_to_wav,
+    convert_timestamp,
+    delete_file,
+    format_punct,
+    is_empty_string,
+)
+
+
+router = APIRouter()
+
+
+@router.post("/audio", response_model=ASRResponse, status_code=http_status.HTTP_200_OK)
+async def inference_with_audio(
+    background_tasks: BackgroundTasks,
+    file: UploadFile = File(...),  # noqa: B008
+    data: Optional[DataRequest] = None,
+) -> ASRResponse:
+    """Inference endpoint with audio file."""
+    extension = file.filename.split(".")[-1]
+    filename = f"audio_{shortuuid.ShortUUID().random(length=32)}.{extension}"
+
+    async with aiofiles.open(filename, "wb") as f:
+        audio_bytes = await file.read()
+        await f.write(audio_bytes)
+
+    if extension != "wav":
+        filepath = await convert_file_to_wav(filename)
+        background_tasks.add_task(delete_file, filepath=filename)
+    else:
+        filepath = filename
+
+    if data is None:
+        data = DataRequest()
+    else:
+        data = DataRequest(**data.dict())
+
+    raw_utterances = await asr.process_input(filepath, data.source_lang)
+
+    timestamps_format = data.timestamps
+    utterances = [
+        {
+            "text": format_punct(utterance["text"]),
+            "start": convert_timestamp(utterance["start"], timestamps_format),
+            "end": convert_timestamp(utterance["end"], timestamps_format),
+            "speaker": int(utterance["speaker"]),
+        }
+        for utterance in raw_utterances
+        if not is_empty_string(utterance["text"])
+    ]
+
+    background_tasks.add_task(delete_file, filepath=filepath)
+
+    return ASRResponse(utterances=utterances)

--- a/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -17,7 +17,6 @@ from typing import Optional
 
 import aiofiles
 import shortuuid
-
 from fastapi import APIRouter, BackgroundTasks, File, UploadFile
 from fastapi import status as http_status
 

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -1,0 +1,76 @@
+# Copyright 2023 The Wordcab Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Audio url endpoint for the Wordcab Transcribe API."""
+
+from typing import Optional
+
+import shortuuid
+
+from fastapi import APIRouter, BackgroundTasks
+from fastapi import status as http_status
+
+from wordcab_transcribe.dependencies import asr
+from wordcab_transcribe.models import ASRResponse, DataRequest
+from wordcab_transcribe.utils import (
+    convert_file_to_wav,
+    convert_timestamp,
+    delete_file,
+    download_audio_file,
+    format_punct,
+    is_empty_string,
+)
+
+
+router = APIRouter()
+
+
+@router.post("/audio-url", response_model=ASRResponse, status_code=http_status.HTTP_200_OK)
+async def inference_with_audio_url(
+    background_tasks: BackgroundTasks,
+    url: str,
+    data: Optional[DataRequest] = None,
+) -> ASRResponse:
+    """Inference endpoint with audio url."""
+    filename = f"audio_url_{shortuuid.ShortUUID().random(length=32)}"
+    filepath = await download_audio_file(url, filename)
+    extension = filepath.split(".")[-1]
+
+    if extension != "wav":
+        filepath = await convert_file_to_wav(filepath)
+        background_tasks.add_task(delete_file, filepath=f"{filename}.{extension}")
+    else:
+        filepath = filename
+
+    if data is None:
+        data = DataRequest()
+    else:
+        data = DataRequest(**data.dict())
+
+    raw_utterances = await asr.process_input(filepath, data.source_lang)
+
+    timestamps_format = data.timestamps
+    utterances = [
+        {
+            "text": format_punct(utterance["text"]),
+            "start": convert_timestamp(utterance["start"], timestamps_format),
+            "end": convert_timestamp(utterance["end"], timestamps_format),
+            "speaker": int(utterance["speaker"]),
+        }
+        for utterance in raw_utterances
+        if not is_empty_string(utterance["text"])
+    ]
+
+    background_tasks.add_task(delete_file, filepath=filepath)
+
+    return ASRResponse(utterances=utterances)

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -16,7 +16,6 @@
 from typing import Optional
 
 import shortuuid
-
 from fastapi import APIRouter, BackgroundTasks
 from fastapi import status as http_status
 
@@ -35,7 +34,9 @@ from wordcab_transcribe.utils import (
 router = APIRouter()
 
 
-@router.post("/audio-url", response_model=ASRResponse, status_code=http_status.HTTP_200_OK)
+@router.post(
+    "/audio-url", response_model=ASRResponse, status_code=http_status.HTTP_200_OK
+)
 async def inference_with_audio_url(
     background_tasks: BackgroundTasks,
     url: str,

--- a/wordcab_transcribe/router/v1/endpoints.py
+++ b/wordcab_transcribe/router/v1/endpoints.py
@@ -15,10 +15,10 @@
 
 from fastapi import APIRouter
 
-from wordcab_transcribe.router.v1.audio_file_endpoint import router as audio_file_endpoint
-from wordcab_transcribe.router.v1.audio_url_endpoint import router as audio_url_endpoint
-from wordcab_transcribe.router.v1.live_endpoints import router as live_endpoint
-from wordcab_transcribe.router.v1.youtube_endpoint import router as youtube_endpoint
+from wordcab_transcribe.router.v1.audio_file_endpoint import router as audio_file_router
+from wordcab_transcribe.router.v1.audio_url_endpoint import router as audio_url_router
+from wordcab_transcribe.router.v1.live_endpoints import router as live_router
+from wordcab_transcribe.router.v1.youtube_endpoint import router as youtube_router
 from wordcab_transcribe.config import settings
 
 
@@ -27,14 +27,15 @@ api_router = APIRouter()
 include_api = api_router.include_router
 
 routers = (
-    (audio_file_endpoint, "/audio", "async"),
-    (audio_url_endpoint, "/audio-url", "async"),
-    (youtube_endpoint, "/youtube", "async")
-    (live_endpoint, "/live", "live")
+    ("audio_file_endpoint", audio_file_router, "/audio", "async"),
+    ("audio_url_endpoint", audio_url_router, "/audio-url", "async"),
+    ("youtube_endpoint", youtube_router, "/youtube", "async"),
+    ("live_endpoint", live_router, "/live", "live"),
 )
 
 for router_items in routers:
-    router, prefix, tags = router_items
+    endpoint, router, prefix, tags = router_items
 
-    if getattr(settings, router) is True:
+    # If the endpoint is enabled, include it in the API.
+    if getattr(settings, endpoint) is True:
         include_api(router, prefix=prefix, tags=[tags])

--- a/wordcab_transcribe/router/v1/endpoints.py
+++ b/wordcab_transcribe/router/v1/endpoints.py
@@ -15,11 +15,11 @@
 
 from fastapi import APIRouter
 
+from wordcab_transcribe.config import settings
 from wordcab_transcribe.router.v1.audio_file_endpoint import router as audio_file_router
 from wordcab_transcribe.router.v1.audio_url_endpoint import router as audio_url_router
 from wordcab_transcribe.router.v1.live_endpoints import router as live_router
 from wordcab_transcribe.router.v1.youtube_endpoint import router as youtube_router
-from wordcab_transcribe.config import settings
 
 
 api_router = APIRouter()

--- a/wordcab_transcribe/router/v1/endpoints.py
+++ b/wordcab_transcribe/router/v1/endpoints.py
@@ -1,0 +1,40 @@
+# Copyright 2023 The Wordcab Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Routing the requested endpoints to the API."""
+
+from fastapi import APIRouter
+
+from wordcab_transcribe.router.v1.audio_file_endpoint import router as audio_file_endpoint
+from wordcab_transcribe.router.v1.audio_url_endpoint import router as audio_url_endpoint
+from wordcab_transcribe.router.v1.live_endpoints import router as live_endpoint
+from wordcab_transcribe.router.v1.youtube_endpoint import router as youtube_endpoint
+from wordcab_transcribe.config import settings
+
+
+api_router = APIRouter()
+
+include_api = api_router.include_router
+
+routers = (
+    (audio_file_endpoint, "/audio", "async"),
+    (audio_url_endpoint, "/audio-url", "async"),
+    (youtube_endpoint, "/youtube", "async")
+    (live_endpoint, "/live", "live")
+)
+
+for router_items in routers:
+    router, prefix, tags = router_items
+
+    if getattr(settings, router) is True:
+        include_api(router, prefix=prefix, tags=[tags])

--- a/wordcab_transcribe/router/v1/live_endpoints.py
+++ b/wordcab_transcribe/router/v1/live_endpoints.py
@@ -1,0 +1,25 @@
+# Copyright 2023 The Wordcab Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Live endpoints for the Wordcab Transcribe API."""
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.post("/live")
+async def live() -> None:
+    """Live endpoint for the API."""
+    pass

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -16,7 +16,6 @@
 from typing import Optional
 
 import shortuuid
-
 from fastapi import APIRouter, BackgroundTasks
 from fastapi import status as http_status
 
@@ -34,7 +33,9 @@ from wordcab_transcribe.utils import (
 router = APIRouter()
 
 
-@router.post("/youtube", response_model=ASRResponse, status_code=http_status.HTTP_200_OK)
+@router.post(
+    "/youtube", response_model=ASRResponse, status_code=http_status.HTTP_200_OK
+)
 async def inference_with_youtube(
     background_tasks: BackgroundTasks,
     url: str,

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -1,0 +1,68 @@
+# Copyright 2023 The Wordcab Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Youtube endpoint for the Wordcab Transcribe API."""
+
+from typing import Optional
+
+import shortuuid
+
+from fastapi import APIRouter, BackgroundTasks
+from fastapi import status as http_status
+
+from wordcab_transcribe.dependencies import asr
+from wordcab_transcribe.models import ASRResponse, DataRequest
+from wordcab_transcribe.utils import (
+    convert_timestamp,
+    delete_file,
+    download_file_from_youtube,
+    format_punct,
+    is_empty_string,
+)
+
+
+router = APIRouter()
+
+
+@router.post("/youtube", response_model=ASRResponse, status_code=http_status.HTTP_200_OK)
+async def inference_with_youtube(
+    background_tasks: BackgroundTasks,
+    url: str,
+    data: Optional[DataRequest] = None,
+) -> ASRResponse:
+    """Inference endpoint with YouTube url."""
+    filename = f"yt_{shortuuid.ShortUUID().random(length=32)}"
+    filepath = await download_file_from_youtube(url, filename)
+
+    if data is None:
+        data = DataRequest()
+    else:
+        data = DataRequest(**data.dict())
+
+    raw_utterances = await asr.process_input(filepath, data.source_lang)
+
+    timestamps_format = data.timestamps
+    utterances = [
+        {
+            "text": format_punct(utterance["text"]),
+            "start": convert_timestamp(utterance["start"], timestamps_format),
+            "end": convert_timestamp(utterance["end"], timestamps_format),
+            "speaker": int(utterance["speaker"]),
+        }
+        for utterance in raw_utterances
+        if not is_empty_string(utterance["text"])
+    ]
+
+    background_tasks.add_task(delete_file, filepath=filepath)
+
+    return ASRResponse(utterances=utterances)


### PR DESCRIPTION
This PR adds routing stuff to the API.

- Each endpoint now has a separated file in `wordcab_transcribe/router/v1/[endpoint_name].py`
- You can choose which endpoint you want to use when launching your API by updating the config file.
Choose `True` or `False` to load or not load an endpoint.
- The `ASRService` has been moved to the new dependencies file, which allows multiple endpoints to use the same instantiated class. It will not impact the future split/modularity of the `ASRService`.
- I took the opportunity to rename the root endpoint `/`: `async def home()`. And the endpoint will be updated in the future PR to match the Cortex requirements.
- I have added an `/healthz` endpoint.