### PR TITLE
Add customization to api

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6786,4 +6786,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<3.10"
-content-hash = "3561b823fd8340a558747344dbaf0aef4767e7a83b278b378e08776585dc24f7"
+content-hash = "83a0f2c20e4dbc0169531d3de7b9d61e0c48a87f702195796ab33177a63e773b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ loguru = ">=0.6.0"
 nemo-toolkit = { version = ">=1.17.0", extras = ["asr"] }
 numpy = "==1.23.1"
 num2words = ">=0.5.12"
-onnxruntime = ">=1.14.1"
 pydantic = ">=1.10.7"
 pydub = ">=0.25.1"
 python-dotenv = ">=1.0.0"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -47,24 +47,34 @@ def test_audio_response() -> None:
     response = AudioResponse(
         utterances=[],
         alignment=False,
+        diarization=False,
         dual_channel=False,
         source_lang="en",
         timestamps="s",
+        word_timestamps=False,
     )
     assert response.utterances == []
     assert response.alignment is False
+    assert response.diarization is False
     assert response.dual_channel is False
     assert response.source_lang == "en"
     assert response.timestamps == "s"
+    assert response.word_timestamps is False
 
     response = AudioResponse(
-        utterances=["Hello", "world"],
+        utterances=[
+            {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+            {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
+        ],
         alignment=True,
         dual_channel=True,
         source_lang="en",
         timestamps="s",
     )
-    assert response.utterances == ["Hello", "world"]
+    assert response.utterances == [
+        {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+        {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
+    ]
     assert response.alignment is True
     assert response.dual_channel is True
     assert response.source_lang == "en"
@@ -101,15 +111,25 @@ def test_base_request_invalid() -> None:
 def test_base_response() -> None:
     """Test the BaseResponse model."""
     response = BaseResponse(
-        utterances=["Hello", "world"],
+        utterances=[
+            {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+            {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
+        ],
         alignment=True,
+        diarization=False,
         source_lang="en",
         timestamps="s",
+        word_timestamps=False,
     )
-    assert response.utterances == ["Hello", "world"]
+    assert response.utterances == [
+        {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+        {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
+    ]
     assert response.alignment is True
+    assert response.diarization is False
     assert response.source_lang == "en"
     assert response.timestamps == "s"
+    assert response.word_timestamps is False
 
 
 def test_cortex_error() -> None:
@@ -127,9 +147,11 @@ def test_corxet_payload() -> None:
         url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         api_key="test_api_key",
         alignment=True,
+        diarization=False,
         dual_channel=False,
         source_lang="en",
         timestamps="s",
+        word_timestamps=False,
         job_name="test_job",
         ping=False,
     )
@@ -137,9 +159,11 @@ def test_corxet_payload() -> None:
     assert payload.url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     assert payload.api_key == "test_api_key"
     assert payload.alignment is True
+    assert payload.diarization is False
     assert payload.dual_channel is False
     assert payload.source_lang == "en"
     assert payload.timestamps == "s"
+    assert payload.word_timestamps is False
     assert payload.job_name == "test_job"
     assert payload.ping is False
 
@@ -147,18 +171,28 @@ def test_corxet_payload() -> None:
 def test_cortex_url_response() -> None:
     """Test the CortexUrlResponse model."""
     response = CortexUrlResponse(
-        utterances=["Hello", "world"],
+        utterances=[
+            {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+            {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
+        ],
         alignment=True,
+        diarization=False,
         source_lang="en",
         timestamps="s",
+        word_timestamps=False,
         dual_channel=False,
         job_name="test_job",
         request_id="test_request_id",
     )
-    assert response.utterances == ["Hello", "world"]
+    assert response.utterances == [
+        {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+        {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
+    ]
     assert response.alignment is True
+    assert response.diarization is False
     assert response.source_lang == "en"
     assert response.timestamps == "s"
+    assert response.word_timestamps is False
     assert response.dual_channel is False
     assert response.job_name == "test_job"
     assert response.request_id == "test_request_id"
@@ -167,21 +201,28 @@ def test_cortex_url_response() -> None:
 def test_cortex_youtube_response() -> None:
     """Test the CortexYoutubeResponse model."""
     response = CortexYoutubeResponse(
-        utterances=["Never gonna give you up", "Never gonna let you down"],
+        utterances=[
+            {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+            {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
+        ],
         alignment=True,
+        diarization=False,
         source_lang="en",
         timestamps="s",
+        word_timestamps=False,
         video_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         job_name="test_job",
         request_id="test_request_id",
     )
     assert response.utterances == [
-        "Never gonna give you up",
-        "Never gonna let you down",
+        {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+        {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
     ]
     assert response.alignment is True
+    assert response.diarization is False
     assert response.source_lang == "en"
     assert response.timestamps == "s"
+    assert response.word_timestamps is False
     assert response.video_url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     assert response.job_name == "test_job"
     assert response.request_id == "test_request_id"
@@ -190,17 +231,24 @@ def test_cortex_youtube_response() -> None:
 def test_youtube_response() -> None:
     """Test the YouTubeResponse model."""
     response = YouTubeResponse(
-        utterances=["Never gonna give you up", "Never gonna let you down"],
+        utterances=[
+            {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+            {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
+        ],
         alignment=True,
+        diarization=False,
         source_lang="en",
         timestamps="s",
+        word_timestamps=False,
         video_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
     )
     assert response.utterances == [
-        "Never gonna give you up",
-        "Never gonna let you down",
+        {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
+        {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
     ]
     assert response.alignment is True
+    assert response.diarization is False
     assert response.source_lang == "en"
     assert response.timestamps == "s"
+    assert response.word_timestamps is False
     assert response.video_url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -67,18 +67,22 @@ def test_audio_response() -> None:
             {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
         ],
         alignment=True,
+        diarization=True,
         dual_channel=True,
         source_lang="en",
         timestamps="s",
+        word_timestamps=True,
     )
     assert response.utterances == [
         {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
         {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
     ]
     assert response.alignment is True
+    assert response.diarization is True
     assert response.dual_channel is True
     assert response.source_lang == "en"
     assert response.timestamps == "s"
+    assert response.word_timestamps is True
 
 
 def test_base_request_valid() -> None:

--- a/tests/utils/test_convert_functions.py
+++ b/tests/utils/test_convert_functions.py
@@ -28,23 +28,6 @@ from wordcab_transcribe.utils import (
 @pytest.mark.parametrize(
     "timestamp, target, expected",
     [
-        (1000, "ms", 1000),
-        (1000, "s", 1),
-        (1000, "hms", "00:00:01.000"),
-        (3600000, "hms", "01:00:00.000"),
-        (3661000, "hms", "01:01:01.000"),
-    ],
-)
-def test_convert_timestamp_dual_channel_false(
-    timestamp: float, target: str, expected: Union[str, float]
-) -> None:
-    """Test the convert_timestamp function."""
-    assert convert_timestamp(timestamp, target, False) == expected
-
-
-@pytest.mark.parametrize(
-    "timestamp, target, expected",
-    [
         (1, "ms", 1000),
         (1, "s", 1),
         (1, "hms", "00:00:01.000"),
@@ -52,11 +35,11 @@ def test_convert_timestamp_dual_channel_false(
         (3661, "hms", "01:01:01.000"),
     ],
 )
-def test_convert_timestamp_dual_channel_true(
+def test_convert_timestamp(
     timestamp: float, target: str, expected: Union[str, float]
 ) -> None:
     """Test the convert_timestamp function."""
-    assert convert_timestamp(timestamp, target, True) == expected
+    assert convert_timestamp(timestamp, target) == expected
 
 
 def test_convert_timestamp_raises_error() -> None:

--- a/wordcab_transcribe/models.py
+++ b/wordcab_transcribe/models.py
@@ -41,16 +41,16 @@ class AudioResponse(BaseResponse):
             "example": {
                 "utterances": [
                     {
-                        "speaker": 0,
-                        "start": 0.0,
-                        "end": 1.0,
                         "text": "Hello World!",
+                        "start": 0.345,
+                        "end": 1.234,
+                        "speaker": 0,
                     },
                     {
-                        "speaker": 0,
-                        "start": 1.0,
-                        "end": 2.0,
                         "text": "Wordcab is awesome",
+                        "start": 1.234,
+                        "end": 2.678,
+                        "speaker": 1,
                     },
                 ],
                 "alignment": False,

--- a/wordcab_transcribe/models.py
+++ b/wordcab_transcribe/models.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Models module of the Wordcab Transcribe."""
 
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, validator
 
@@ -21,10 +21,12 @@ from pydantic import BaseModel, validator
 class BaseResponse(BaseModel):
     """Base response model, not meant to be used directly."""
 
-    utterances: list
+    utterances: List[dict]
     alignment: bool
+    diarization: bool
     source_lang: str
     timestamps: str
+    word_timestamps: bool
 
 
 class AudioResponse(BaseResponse):
@@ -52,9 +54,11 @@ class AudioResponse(BaseResponse):
                     },
                 ],
                 "alignment": False,
-                "dual_channel": False,
+                "diarization": False,
                 "source_lang": "en",
                 "timestamps": "s",
+                "word_timestamps": False,
+                "dual_channel": False,
             }
         }
 
@@ -84,8 +88,10 @@ class YouTubeResponse(BaseResponse):
                     },
                 ],
                 "alignment": False,
+                "diarization": False,
                 "source_lang": "en",
                 "timestamps": "s",
+                "word_timestamps": False,
                 "video_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             }
         }
@@ -113,9 +119,11 @@ class CortexPayload(BaseModel):
     url: str = None
     api_key: str = None
     alignment: Optional[bool] = False
+    diarization: Optional[bool] = False
     dual_channel: Optional[bool] = False
     source_lang: Optional[str] = "en"
     timestamps: Optional[str] = "s"
+    word_timestamps: Optional[bool] = False
     job_name: Optional[str] = None
     ping: Optional[bool] = False
 
@@ -142,9 +150,11 @@ class CortexPayload(BaseModel):
                 "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                 "api_key": "1234567890",
                 "alignment": False,
+                "diarization": False,
                 "dual_channel": False,
                 "source_lang": "en",
                 "timestamps": "s",
+                "word_timestamps": False,
                 "job_name": "job_abc123",
                 "ping": False,
             }
@@ -177,9 +187,11 @@ class CortexUrlResponse(AudioResponse):
                     },
                 ],
                 "alignment": False,
-                "dual_channel": False,
+                "diariation": False,
                 "source_lang": "en",
                 "timestamps": "s",
+                "word_timestamps": False,
+                "dual_channel": False,
                 "job_name": "job_name",
                 "request_id": "request_id",
             }
@@ -212,8 +224,10 @@ class CortexYoutubeResponse(YouTubeResponse):
                     },
                 ],
                 "alignment": False,
+                "diariation": False,
                 "source_lang": "en",
                 "timestamps": "s",
+                "word_timestamps": False,
                 "video_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                 "job_name": "job_name",
                 "request_id": "request_id",
@@ -225,8 +239,10 @@ class BaseRequest(BaseModel):
     """Base request model for the API."""
 
     alignment: Optional[bool] = False
+    diarization: Optional[bool] = False
     source_lang: Optional[str] = "en"
     timestamps: Optional[str] = "s"
+    word_timestamps: Optional[bool] = False
 
     @validator("timestamps")
     def validate_timestamps_values(cls, value: str) -> str:  # noqa: B902, N805
@@ -241,8 +257,10 @@ class BaseRequest(BaseModel):
         schema_extra = {
             "example": {
                 "alignment": False,
+                "diarization": False,
                 "source_lang": "en",
                 "timestamps": "s",
+                "word_timestamps": False,
             }
         }
 
@@ -258,9 +276,11 @@ class AudioRequest(BaseRequest):
         schema_extra = {
             "example": {
                 "alignment": False,
-                "dual_channel": False,
+                "diarization": False,
                 "source_lang": "en",
                 "timestamps": "s",
+                "word_timestamps": False,
+                "dual_channel": False,
             }
         }
 

--- a/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -84,7 +84,9 @@ async def inference_with_audio(
             "text": format_punct(utterance["text"]),
             "start": convert_timestamp(utterance["start"], timestamps_format),
             "end": convert_timestamp(utterance["end"], timestamps_format),
-            "speaker": int(utterance["speaker"]) if data.diarization else None,
+            "speaker": int(utterance["speaker"])
+            if data.diarization or data.dual_channel
+            else None,
             "words": utterance["words"] if data.word_timestamps else [],
         }
         for utterance in raw_utterances

--- a/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -82,12 +82,8 @@ async def inference_with_audio(
     utterances = [
         {
             "text": format_punct(utterance["text"]),
-            "start": convert_timestamp(
-                utterance["start"], timestamps_format, data.diarization
-            ),
-            "end": convert_timestamp(
-                utterance["end"], timestamps_format, data.diarization
-            ),
+            "start": convert_timestamp(utterance["start"], timestamps_format),
+            "end": convert_timestamp(utterance["end"], timestamps_format),
             "speaker": int(utterance["speaker"]) if data.diarization else None,
             "words": utterance["words"] if data.word_timestamps else [],
         }

--- a/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -83,12 +83,12 @@ async def inference_with_audio(
         {
             "text": format_punct(utterance["text"]),
             "start": convert_timestamp(
-                utterance["start"], timestamps_format, data.dual_channel
+                utterance["start"], timestamps_format, data.diarization
             ),
             "end": convert_timestamp(
-                utterance["end"], timestamps_format, data.dual_channel
+                utterance["end"], timestamps_format, data.diarization
             ),
-            "speaker": int(utterance["speaker"]),
+            "speaker": int(utterance["speaker"]) if data.diarization else None,
             "words": utterance["words"] if data.word_timestamps else [],
         }
         for utterance in raw_utterances

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -69,12 +69,12 @@ async def inference_with_audio_url(
         {
             "text": format_punct(utterance["text"]),
             "start": convert_timestamp(
-                utterance["start"], timestamps_format, data.dual_channel
+                utterance["start"], timestamps_format, data.diarization
             ),
             "end": convert_timestamp(
-                utterance["end"], timestamps_format, data.dual_channel
+                utterance["end"], timestamps_format, data.diarization
             ),
-            "speaker": int(utterance["speaker"]),
+            "speaker": int(utterance["speaker"]) if data.diarization else None,
             "words": utterance["words"] if data.word_timestamps else [],
         }
         for utterance in raw_utterances

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -61,8 +61,10 @@ async def inference_with_audio_url(
     raw_utterances = await asr.process_input(
         filepath,
         alignment=data.alignment,
+        diarization=data.diarization,
         dual_channel=data.dual_channel,
         source_lang=data.source_lang,
+        word_timestamps=data.word_timestamps,
     )
 
     timestamps_format = data.timestamps
@@ -76,6 +78,7 @@ async def inference_with_audio_url(
                 utterance["end"], timestamps_format, data.dual_channel
             ),
             "speaker": int(utterance["speaker"]),
+            "words": utterance["words"] if data.word_timestamps else [],
         }
         for utterance in raw_utterances
         if not is_empty_string(utterance["text"])
@@ -86,7 +89,9 @@ async def inference_with_audio_url(
     return AudioResponse(
         utterances=utterances,
         alignment=data.alignment,
+        diarization=data.diarization,
         dual_channel=data.dual_channel,
         source_lang=data.source_lang,
         timestamps=data.timestamps,
+        word_timestamps=data.word_timestamps,
     )

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -70,7 +70,9 @@ async def inference_with_audio_url(
             "text": format_punct(utterance["text"]),
             "start": convert_timestamp(utterance["start"], timestamps_format),
             "end": convert_timestamp(utterance["end"], timestamps_format),
-            "speaker": int(utterance["speaker"]) if data.diarization else None,
+            "speaker": int(utterance["speaker"])
+            if data.diarization or data.dual_channel
+            else None,
             "words": utterance["words"] if data.word_timestamps else [],
         }
         for utterance in raw_utterances

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -68,12 +68,8 @@ async def inference_with_audio_url(
     utterances = [
         {
             "text": format_punct(utterance["text"]),
-            "start": convert_timestamp(
-                utterance["start"], timestamps_format, data.diarization
-            ),
-            "end": convert_timestamp(
-                utterance["end"], timestamps_format, data.diarization
-            ),
+            "start": convert_timestamp(utterance["start"], timestamps_format),
+            "end": convert_timestamp(utterance["end"], timestamps_format),
             "speaker": int(utterance["speaker"]) if data.diarization else None,
             "words": utterance["words"] if data.word_timestamps else [],
         }

--- a/wordcab_transcribe/router/v1/cortex_endpoint.py
+++ b/wordcab_transcribe/router/v1/cortex_endpoint.py
@@ -65,9 +65,11 @@ async def run_cortex(
         if payload.url_type == "audio_url":
             data = AudioRequest(
                 alignment=payload.alignment,
+                diarization=payload.diarization,
                 dual_channel=payload.dual_channel,
                 source_lang=payload.source_lang,
                 timestamps=payload.timestamps,
+                word_timestamps=payload.word_timestamps,
             )
             utterances: AudioResponse = await inference_with_audio_url(
                 background_tasks=BackgroundTasks(),

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -58,9 +58,9 @@ async def inference_with_youtube(
     utterances = [
         {
             "text": format_punct(utterance["text"]),
-            "start": convert_timestamp(utterance["start"], timestamps_format, False),
-            "end": convert_timestamp(utterance["end"], timestamps_format, False),
-            "speaker": int(utterance["speaker"]),
+            "start": convert_timestamp(utterance["start"], timestamps_format, data.diarization),
+            "end": convert_timestamp(utterance["end"], timestamps_format, data.diarization),
+            "speaker": int(utterance["speaker"]) if data.diarization else None,
             "words": utterance["words"] if data.word_timestamps else [],
         }
         for utterance in raw_utterances

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -48,8 +48,10 @@ async def inference_with_youtube(
     raw_utterances = await asr.process_input(
         filepath,
         alignment=data.alignment,
+        diarization=data.diarization,
         dual_channel=False,
         source_lang=data.source_lang,
+        word_timestamps=data.word_timestamps,
     )
 
     timestamps_format = data.timestamps
@@ -59,6 +61,7 @@ async def inference_with_youtube(
             "start": convert_timestamp(utterance["start"], timestamps_format, False),
             "end": convert_timestamp(utterance["end"], timestamps_format, False),
             "speaker": int(utterance["speaker"]),
+            "words": utterance["words"] if data.word_timestamps else [],
         }
         for utterance in raw_utterances
         if not is_empty_string(utterance["text"])
@@ -69,7 +72,9 @@ async def inference_with_youtube(
     return YouTubeResponse(
         utterances=utterances,
         alignment=data.alignment,
+        diarization=data.diarization,
         source_lang=data.source_lang,
         timestamps=data.timestamps,
+        word_timestamps=data.word_timestamps,
         video_url=url,
     )

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -58,8 +58,8 @@ async def inference_with_youtube(
     utterances = [
         {
             "text": format_punct(utterance["text"]),
-            "start": convert_timestamp(utterance["start"], timestamps_format, data.diarization),
-            "end": convert_timestamp(utterance["end"], timestamps_format, data.diarization),
+            "start": convert_timestamp(utterance["start"], timestamps_format),
+            "end": convert_timestamp(utterance["end"], timestamps_format),
             "speaker": int(utterance["speaker"]) if data.diarization else None,
             "words": utterance["words"] if data.word_timestamps else [],
         }

--- a/wordcab_transcribe/services/align_service.py
+++ b/wordcab_transcribe/services/align_service.py
@@ -157,6 +157,8 @@ class AlignService:
         result_aligned = self.align(
             transcript_segments, model, metadata, filepath, self.device
         )
+        logger.debug(f"{result_aligned['segments'][0]}")
+        logger.debug(f"{result_aligned['word_segments'][0]}")
         word_timestamps = result_aligned["word_segments"]
 
         del model

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -283,20 +283,6 @@ class ASRAsyncService(ASRService):
 
         return final_transcript
 
-    def diarize(self, filepath: str) -> List[dict]:
-        """
-        Diarize the audio file using the DiarizeService class.
-
-        Args:
-            filepath (str): Path to the audio file.
-
-        Returns:
-            List[dict]: List of speaker timestamps.
-        """
-        speaker_timestamps = self.diarize_model(filepath)
-
-        return speaker_timestamps
-
     def process_batch(self, file_batch: List[dict]) -> List[dict]:
         """
         Process a batch of requests.
@@ -362,7 +348,9 @@ class ASRAsyncService(ASRService):
         formatted_segments = format_segments(segments, alignment=alignment, word_timestamps=word_timestamps)
 
         if diarization:
-            speaker_timestamps = self.diarize(filepath)
+            speaker_timestamps = self.diarize_model(filepath)
+            for ts in speaker_timestamps:
+                logger.debug(f"Speaker timestamps: {ts}")
             utterances = self.post_processing_service.single_channel_postprocessing(
                 transcript_segments=formatted_segments,
                 speaker_timestamps=speaker_timestamps,

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -278,7 +278,7 @@ class ASRAsyncService(ASRService):
                 delete_file(temp_filepath)
 
             except Exception as e:
-                print(f"Error: {e}")
+                logger.error(f"Dual channel trasncription error: {e}")
                 pass
 
         return final_transcript
@@ -296,7 +296,7 @@ class ASRAsyncService(ASRService):
         results: List[dict] = []
         for task in file_batch:
             filepath: Union[str, Tuple[str]] = task["input"]
-            alignment: bool = task["alignment"]  # ignored if diarization is True
+            alignment: bool = task["alignment"]  # ignored if dual_channel is True
             diarization: bool = task["diarization"]  # ignored if dual_channel is True
             dual_channel: bool = task["dual_channel"]
             source_lang: str = task["source_lang"]
@@ -395,6 +395,7 @@ class ASRAsyncService(ASRService):
         utterances = self.post_processing_service.dual_channel_postprocessing(
             left_segments=left_transcribed_segments,
             right_segments=right_transcribed_segments,
+            word_timestamps=word_timestamps,
         )
 
         return utterances

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -340,12 +340,12 @@ class ASRAsyncService(ASRService):
         if alignment:
             # Alignment works best with word timestamps, so we force it for transcription
             _segments = self.transcribe_model(
-                filepath, source_lang, word_timestamps=word_timestamps
+                filepath, source_lang, word_timestamps=True
             )
             segments = self.align_model(filepath, _segments, source_lang)
         else:
             segments = self.transcribe_model(
-                filepath, source_lang, word_timestamps=word_timestamps
+                filepath, source_lang, word_timestamps=True
             )
 
         # Format the segments: the main purpose is to remove extra spaces and

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -16,7 +16,7 @@
 import asyncio
 import traceback
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, List, Tuple, Union
+from typing import List, Tuple, Union
 
 import numpy as np
 import torch
@@ -338,19 +338,23 @@ class ASRAsyncService(ASRService):
         """
         if alignment:
             # Alignment works best with word timestamps, so we force it for transcription
-            _segments = self.transcribe_model(filepath, source_lang, word_timestamps=True)
+            _segments = self.transcribe_model(
+                filepath, source_lang, word_timestamps=True
+            )
             segments = self.align_model(filepath, _segments, source_lang)
         else:
-            segments = self.transcribe_model(filepath, source_lang, word_timestamps=word_timestamps)
+            segments = self.transcribe_model(
+                filepath, source_lang, word_timestamps=word_timestamps
+            )
 
         # Format the segments: the main purpose is to remove extra spaces and
         # to format word_timestamps like the alignment model does
-        formatted_segments = format_segments(segments, alignment=alignment, word_timestamps=word_timestamps)
+        formatted_segments = format_segments(
+            segments, alignment=alignment, word_timestamps=word_timestamps
+        )
 
         if diarization:
             speaker_timestamps = self.diarize_model(filepath)
-            for ts in speaker_timestamps:
-                logger.debug(f"Speaker timestamps: {ts}")
             utterances = self.post_processing_service.single_channel_postprocessing(
                 transcript_segments=formatted_segments,
                 speaker_timestamps=speaker_timestamps,

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -338,7 +338,6 @@ class ASRAsyncService(ASRService):
         """
         alignment = False  # TODO: remove this line when alignment is fixed
         if alignment:
-            # Alignment works best with word timestamps, so we force it for transcription
             _segments = self.transcribe_model(
                 filepath, source_lang, word_timestamps=True
             )
@@ -354,13 +353,8 @@ class ASRAsyncService(ASRService):
             segments, alignment=alignment, word_timestamps=word_timestamps
         )
 
-        for segment in formatted_segments:
-            logger.debug(f"Original segment: {segment}")
-
         if diarization:
             speaker_timestamps = self.diarize_model(filepath)
-            for idx, ts in enumerate(speaker_timestamps):
-                logger.debug(f"{idx} Speaker timestamp: {ts}")
             utterances = self.post_processing_service.single_channel_postprocessing(
                 transcript_segments=formatted_segments,
                 speaker_timestamps=speaker_timestamps,

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -358,8 +358,8 @@ class ASRAsyncService(ASRService):
             segments = self.transcribe_model(filepath, source_lang, word_timestamps=word_timestamps)
 
         # Format the segments: the main purpose is to remove extra spaces and
-        # filter out word_timestamps if they are not requested
-        formatted_segments = format_segments(segments, word_timestamps=word_timestamps)
+        # to format word_timestamps like the alignment model does
+        formatted_segments = format_segments(segments, alignment=alignment, word_timestamps=word_timestamps)
 
         if diarization:
             speaker_timestamps = self.diarize(filepath)

--- a/wordcab_transcribe/services/post_processing_service.py
+++ b/wordcab_transcribe/services/post_processing_service.py
@@ -106,14 +106,8 @@ class PostProcessingService:
             if "end" not in segment:
                 segment["end"] = segment["start"] + 1
 
-            segment_start, segment_end, segment_text = (
-                int(segment["start"] * 1000),
-                int(segment["end"] * 1000),
-                segment["word"],
-            )
-
             segment_position = get_segment_timestamp_anchor(
-                segment_start, segment_end, anchor_option
+                segment["start"], segment["end"], anchor_option
             )
 
             while segment_position > float(end):
@@ -122,14 +116,14 @@ class PostProcessingService:
                 _, end, speaker = speaker_timestamps[turn_idx]
                 if turn_idx == len(speaker_timestamps) - 1:
                     end = get_segment_timestamp_anchor(
-                        segment_start, segment_end, option="end"
+                        segment["start"], segment["end"], option="end"
                     )
                     break
 
             _segment = {
-                "start": segment_start,
-                "end": segment_end,
-                "text": segment_text,
+                "start": segment["start"],
+                "end": segment["end"],
+                "text": segment["text"],
                 "speaker": speaker,
             }
             if word_timestamps:

--- a/wordcab_transcribe/services/post_processing_service.py
+++ b/wordcab_transcribe/services/post_processing_service.py
@@ -15,7 +15,7 @@
 
 from typing import Any, Dict, List
 
-from wordcab_transcribe.utils import get_segment_timestamp_anchor, _convert_ms_to_s
+from wordcab_transcribe.utils import _convert_ms_to_s, get_segment_timestamp_anchor
 
 
 class PostProcessingService:
@@ -26,7 +26,10 @@ class PostProcessingService:
         self.sample_rate = 16000
 
     def single_channel_postprocessing(
-        self, transcript_segments: List[dict], speaker_timestamps: List[dict], word_timestamps: bool
+        self,
+        transcript_segments: List[dict],
+        speaker_timestamps: List[dict],
+        word_timestamps: bool,
     ) -> List[dict]:
         """Run the post-processing functions on the inputs.
 
@@ -53,7 +56,10 @@ class PostProcessingService:
         return utterances
 
     def dual_channel_postprocessing(
-        self, left_segments: List[dict], right_segments: List[dict], word_timestamps: bool
+        self,
+        left_segments: List[dict],
+        right_segments: List[dict],
+        word_timestamps: bool,
     ) -> List[dict]:
         """Run the dual channel post-processing functions on the inputs.
 
@@ -70,7 +76,9 @@ class PostProcessingService:
             List[dict]: List of sentences with speaker mapping.
         """
         utterances = self.merge_segments(left_segments, right_segments)
-        utterances = self.utterances_speaker_mapping_dual_channel(utterances, word_timestamps)
+        utterances = self.utterances_speaker_mapping_dual_channel(
+            utterances, word_timestamps
+        )
 
         return utterances
 
@@ -94,10 +102,14 @@ class PostProcessingService:
             List[dict]: List of transcript segments with speaker mapping.
         """
         speaker_timestamps = [
-            [_convert_ms_to_s(speaker_ts[0]), _convert_ms_to_s(speaker_ts[1]), speaker_ts[2]]
+            [
+                _convert_ms_to_s(speaker_ts[0]),
+                _convert_ms_to_s(speaker_ts[1]),
+                speaker_ts[2],
+            ]
             for speaker_ts in speaker_timestamps
         ]
-        
+
         _, end, speaker = speaker_timestamps[0]
         segment_position, turn_idx = 0, 0
         segment_speaker_mapping = []
@@ -139,7 +151,10 @@ class PostProcessingService:
         return segment_speaker_mapping
 
     def utterances_speaker_mapping(
-        self, transcript_segments: List[dict], speaker_timestamps: List[dict], word_timestamps: bool
+        self,
+        transcript_segments: List[dict],
+        speaker_timestamps: List[dict],
+        word_timestamps: bool,
     ) -> List[dict]:
         """
         Map utterances of the same speaker together.

--- a/wordcab_transcribe/services/transcribe_service.py
+++ b/wordcab_transcribe/services/transcribe_service.py
@@ -41,9 +41,9 @@ class TranscribeService:
         beam_size: Optional[int] = 5,
         length_penalty: Optional[int] = 1,
         patience: Optional[int] = 1,
-        suppress_blank: Optional[bool] = False,
+        suppress_blank: Optional[bool] = True,
         temperature: Optional[List[float]] = [0, 0.2, 0.4, 0.6, 0.8, 1],  # noqa: B006
-        vad_filter: Optional[bool] = True,
+        vad_filter: Optional[bool] = False,
         word_timestamps: Optional[bool] = False,
     ) -> List[dict]:
         """
@@ -57,7 +57,7 @@ class TranscribeService:
             patience (Optional[int], optional): Patience to use for inference. Defaults to 1.
             suppress_blank (Optional[bool], optional): Whether to suppress blank tokens. Defaults to False.
             temperature (Optional[List[float]], optional): Temperature to use for inference. Defaults to [0, 0.2, 0.4, 0.6, 0.8, 1].  # noqa: B950
-            vad_filter (Optional[bool], optional): Whether to apply VAD filtering. Defaults to True.
+            vad_filter (Optional[bool], optional): Whether to apply VAD filtering. Defaults to False.
             word_timestamps (Optional[bool], optional): Whether to return word timestamps. Defaults to False.
 
         Returns:

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -424,12 +424,13 @@ def format_punct(text: str):
     return text.strip()
 
 
-def format_segments(segments: list, word_timestamps: bool) -> List[dict]:
+def format_segments(segments: list, alignment: bool, word_timestamps: bool) -> List[dict]:
     """
     Format the segments to a list of dicts with start, end and text keys. Optionally include word timestamps.
 
     Args:
         segments (list): List of segments.
+        alignment (bool): Whether the segments have been aligned. Used to format the word timestamps correctly.
         word_timestamps (bool): Whether to include word timestamps.
 
     Returns:
@@ -444,7 +445,19 @@ def format_segments(segments: list, word_timestamps: bool) -> List[dict]:
         segment_dict["end"] = segment["end"]
         segment_dict["text"] = segment["text"].strip()
         if word_timestamps:
-            segment_dict["words"] = segment["words"]
+            if alignment:
+                segment_dict["words"] = segment["words"]
+            else:
+                _words = [
+                    {
+                        "word": word.word.strip(),
+                        "start": word.start,
+                        "end": word.end,
+                        "score": round(word.probability, 3),
+                    }
+                    for word in segment["words"]
+                ]
+                segment_dict["words"] = _words
 
         formatted_segments.append(segment_dict)
 

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -99,7 +99,7 @@ def run_subprocess(command: List[str]) -> tuple:
 
 
 def convert_timestamp(
-    timestamp: float, target: str, round_digits: int = 3
+    timestamp: float, target: str, round_digits: Optional[int] = 3
 ) -> Union[str, float]:
     """
     Use the right function to convert the timestamp.
@@ -410,7 +410,9 @@ def format_punct(text: str):
     return text.strip()
 
 
-def format_segments(segments: list, alignment: bool, word_timestamps: bool) -> List[dict]:
+def format_segments(
+    segments: list, alignment: bool, word_timestamps: bool
+) -> List[dict]:
     """
     Format the segments to a list of dicts with start, end and text keys. Optionally include word timestamps.
 

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -99,7 +99,7 @@ def run_subprocess(command: List[str]) -> tuple:
 
 
 def convert_timestamp(
-    timestamp: float, target: str, diarization: bool, round_digits: int = 3
+    timestamp: float, target: str, round_digits: int = 3
 ) -> Union[str, float]:
     """
     Use the right function to convert the timestamp.
@@ -107,8 +107,6 @@ def convert_timestamp(
     Args:
         timestamp (float): Timestamp to convert.
         target (str): Timestamp to convert.
-        diarization (bool): Whether the audio is diarized or not. If False, the
-            timestamp is already in seconds. If True, the timestamp is in milliseconds.
         round_digits (int, optional): Number of digits to round the timestamp. Defaults to 3.
 
     Returns:
@@ -117,28 +115,16 @@ def convert_timestamp(
     Raises:
         ValueError: If the target is invalid. Valid targets are: ms, hms, s.
     """
-    if diarization:
-        if target == "ms":
-            return round(timestamp, round_digits)
-        elif target == "hms":
-            return _convert_ms_to_hms(timestamp)
-        elif target == "s":
-            return round(_convert_ms_to_s(timestamp), round_digits)
-        else:
-            raise ValueError(
-                f"Invalid conversion target: {target}. Valid targets are: ms, hms, s."
-            )
+    if target == "ms":
+        return round(_convert_s_to_ms(timestamp), round_digits)
+    elif target == "hms":
+        return _convert_s_to_hms(timestamp)
+    elif target == "s":
+        return round(timestamp, round_digits)
     else:
-        if target == "ms":
-            return round(_convert_s_to_ms(timestamp), round_digits)
-        elif target == "hms":
-            return _convert_s_to_hms(timestamp)
-        elif target == "s":
-            return round(timestamp, round_digits)
-        else:
-            raise ValueError(
-                f"Invalid conversion target: {target}. Valid targets are: ms, hms, s."
-            )
+        raise ValueError(
+            f"Invalid conversion target: {target}. Valid targets are: ms, hms, s."
+        )
 
 
 def _convert_ms_to_hms(timestamp: float) -> str:

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -416,12 +416,13 @@ def format_punct(text: str):
     return text.strip()
 
 
-def format_segments(segments: list) -> List[dict]:
+def format_segments(segments: list, word_timestamps: bool) -> List[dict]:
     """
-    Format the segments to a list of dicts with start, end and text keys.
+    Format the segments to a list of dicts with start, end and text keys. Optionally include word timestamps.
 
     Args:
         segments (list): List of segments.
+        word_timestamps (bool): Whether to include word timestamps.
 
     Returns:
         list: List of dicts with start, end and word keys.
@@ -434,6 +435,8 @@ def format_segments(segments: list) -> List[dict]:
         segment_dict["start"] = segment["start"]
         segment_dict["end"] = segment["end"]
         segment_dict["word"] = segment["text"].strip()
+        if word_timestamps:
+            segment_dict["words"] = segment["words"]
 
         formatted_segments.append(segment_dict)
 

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -99,7 +99,7 @@ def run_subprocess(command: List[str]) -> tuple:
 
 
 def convert_timestamp(
-    timestamp: float, target: str, dual_channel: bool
+    timestamp: float, target: str, diarization: bool, round_digits: int = 3
 ) -> Union[str, float]:
     """
     Use the right function to convert the timestamp.
@@ -107,8 +107,9 @@ def convert_timestamp(
     Args:
         timestamp (float): Timestamp to convert.
         target (str): Timestamp to convert.
-        dual_channel (bool): Whether the audio is dual channel or not. If True, the
-            timestamp is already in seconds. If False, the timestamp is in milliseconds.
+        diarization (bool): Whether the audio is diarized or not. If False, the
+            timestamp is already in seconds. If True, the timestamp is in milliseconds.
+        round_digits (int, optional): Number of digits to round the timestamp. Defaults to 3.
 
     Returns:
         Union[str, float]: Converted timestamp.
@@ -116,24 +117,24 @@ def convert_timestamp(
     Raises:
         ValueError: If the target is invalid. Valid targets are: ms, hms, s.
     """
-    if dual_channel:
+    if diarization:
         if target == "ms":
-            return _convert_s_to_ms(timestamp)
+            return round(timestamp, round_digits)
         elif target == "hms":
-            return _convert_s_to_hms(timestamp)
+            return _convert_ms_to_hms(timestamp)
         elif target == "s":
-            return timestamp
+            return round(_convert_ms_to_s(timestamp), round_digits)
         else:
             raise ValueError(
                 f"Invalid conversion target: {target}. Valid targets are: ms, hms, s."
             )
     else:
         if target == "ms":
-            return timestamp
+            return round(_convert_s_to_ms(timestamp), round_digits)
         elif target == "hms":
-            return _convert_ms_to_hms(timestamp)
+            return _convert_s_to_hms(timestamp)
         elif target == "s":
-            return _convert_ms_to_s(timestamp)
+            return round(timestamp, round_digits)
         else:
             raise ValueError(
                 f"Invalid conversion target: {target}. Valid targets are: ms, hms, s."
@@ -441,7 +442,7 @@ def format_segments(segments: list, word_timestamps: bool) -> List[dict]:
 
         segment_dict["start"] = segment["start"]
         segment_dict["end"] = segment["end"]
-        segment_dict["word"] = segment["text"].strip()
+        segment_dict["text"] = segment["text"].strip()
         if word_timestamps:
             segment_dict["words"] = segment["words"]
 


### PR DESCRIPTION
This PR fixes #54 and #36:
* Add the possibility to do transcription with or without `diarization`
* Add the possibility to get `word_timestamps` in the output for the user
* Streamline the post-processus for transcribing an audio file (with or without alignment, diarization and word_timestamps)
* `faster-whisper` always use `word_timestamps` for precision (even when they are removed from the outputs
* Remove unused `onnxruntime` dependency
* Simplify timestamps conversion for the outputs