### PR TITLE
Add timing metrics + logging middleware

### DIFF
--- a/wordcab_transcribe/logging.py
+++ b/wordcab_transcribe/logging.py
@@ -1,0 +1,108 @@
+# Copyright 2023 The Wordcab Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Logging module to add a logging middleware to the Wordcab Transcribe API."""
+
+import asyncio
+import sys
+import time
+from functools import wraps
+from typing import Awaitable, Callable
+
+from fastapi import Request
+from loguru import logger
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from wordcab_transcribe.config import settings
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    """Middleware to log requests, responses, errors and execution time."""
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+        logger.remove()
+        logger.add(
+            sys.stdout,
+            level="DEBUG" if settings.debug else "WARNING"  # Avoid logging debug messages in prod
+        )
+
+    async def dispatch(
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        """
+        Dispatch a request and log it, along with the response and any errors.
+
+        Args:
+            request: The request to dispatch.
+            call_next: The next middleware to call.
+
+        Returns:
+            The response from the next middleware.
+        """
+        start_time = time.time()
+        logger.debug(f"Request: {request.method} {request.url}")
+
+        response = await call_next(request)
+
+        process_time = time.time() - start_time
+        logger.debug(f"Response status: {response.status_code}, Process Time: {process_time:.4f} secs")
+
+        return response
+
+
+def time_and_tell(func: Callable) -> Callable:
+    """
+    This decorator logs the execution time of a function only if the debug setting is True.
+
+    Args:
+        func: The function to decorate.
+
+    Returns:
+        The appropriate wrapper for the function.
+    """
+
+    @wraps(func)
+
+    def sync_wrapper(*args, **kwargs) -> Callable:
+        """Sync wrapper for the decorated function."""
+        if settings.debug:
+            start_time = time.time()
+
+            result = func(*args, **kwargs)
+
+            process_time = time.time() - start_time
+            logger.debug(f"{func.__name__} executed in {process_time:.4f} secs")
+        else:
+            result = func(*args, **kwargs)
+
+        return result
+
+    async def async_wrapper(*args, **kwargs) -> Awaitable:
+        """Async wrapper for the decorated function."""
+        if settings.debug:
+            start_time = time.time()
+
+            result = await func(*args, **kwargs)
+
+            process_time = time.time() - start_time
+            logger.debug(f"{func.__name__} executed in {process_time:.4f} secs")
+        else:
+            result = await func(*args, **kwargs)
+
+        return result
+
+    return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
+    

--- a/wordcab_transcribe/logging.py
+++ b/wordcab_transcribe/logging.py
@@ -20,7 +20,6 @@ import time
 from functools import wraps
 from typing import Awaitable, Callable
 
-from fastapi import Request
 from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -32,16 +31,21 @@ from wordcab_transcribe.config import settings
 
 class LoggingMiddleware(BaseHTTPMiddleware):
     """Middleware to log requests, responses, errors and execution time."""
+
     def __init__(self, app: ASGIApp) -> None:
+        """Initialize the middleware."""
         super().__init__(app)
         logger.remove()
         logger.add(
             sys.stdout,
-            level="DEBUG" if settings.debug else "WARNING"  # Avoid logging debug messages in prod
+            level="DEBUG"
+            if settings.debug
+            else "WARNING",  # Avoid logging debug messages in prod
         )
 
     async def dispatch(
-        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]) -> Response:
+        self, request: Request, call_next: Callable[[Request], Awaitable[Response]]
+    ) -> Response:
         """
         Dispatch a request and log it, along with the response and any errors.
 
@@ -58,7 +62,9 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         response = await call_next(request)
 
         process_time = time.time() - start_time
-        logger.debug(f"Response status: {response.status_code}, Process Time: {process_time:.4f} secs")
+        logger.debug(
+            f"Response status: {response.status_code}, Process Time: {process_time:.4f} secs"
+        )
 
         return response
 
@@ -75,7 +81,6 @@ def time_and_tell(func: Callable) -> Callable:
     """
 
     @wraps(func)
-
     def sync_wrapper(*args, **kwargs) -> Callable:
         """Sync wrapper for the decorated function."""
         if settings.debug:
@@ -105,4 +110,3 @@ def time_and_tell(func: Callable) -> Callable:
         return result
 
     return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
-    

--- a/wordcab_transcribe/main.py
+++ b/wordcab_transcribe/main.py
@@ -23,6 +23,7 @@ from loguru import logger
 
 from wordcab_transcribe.config import settings
 from wordcab_transcribe.dependencies import asr
+from wordcab_transcribe.logging import LoggingMiddleware
 from wordcab_transcribe.router.authentication import get_current_user
 from wordcab_transcribe.router.v1.endpoints import (
     api_router,
@@ -32,6 +33,7 @@ from wordcab_transcribe.router.v1.endpoints import (
 from wordcab_transcribe.utils import retrieve_user_platform
 
 
+# Main application instance creation
 app = FastAPI(
     title=settings.project_name,
     version=settings.version,
@@ -39,6 +41,10 @@ app = FastAPI(
     debug=settings.debug,
 )
 
+# Add logging middleware
+app.add_middleware(LoggingMiddleware)
+
+# Include the appropiate routers based on the settings
 if settings.debug is False:
     app.include_router(auth_router, tags=["authentication"])
     app.include_router(

--- a/wordcab_transcribe/services/align_service.py
+++ b/wordcab_transcribe/services/align_service.py
@@ -25,6 +25,7 @@ import torchaudio
 from loguru import logger
 from transformers import Wav2Vec2ForCTC, Wav2Vec2Processor
 
+from wordcab_transcribe.logging import time_and_tell
 from wordcab_transcribe.utils import interpolate_nans
 
 
@@ -137,6 +138,7 @@ class AlignService:
         self.model_map = MODEL_MAPPING
         self.available_lang = self.model_map.keys()
 
+    @time_and_tell
     def __call__(
         self, filepath: str, transcript_segments: List[dict], source_lang: str
     ) -> List[SingleAlignedSegment]:

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -24,6 +24,7 @@ import torch
 from loguru import logger
 
 from wordcab_transcribe.config import settings
+from wordcab_transcribe.logging import time_and_tell
 from wordcab_transcribe.services.align_service import AlignService
 from wordcab_transcribe.services.diarize_service import DiarizeService
 from wordcab_transcribe.services.post_processing_service import PostProcessingService
@@ -162,6 +163,7 @@ class ASRAsyncService(ASRService):
                 self.needs_processing[task_type].set,
             )
 
+    @time_and_tell
     async def process_input(
         self,
         filepath: Union[str, Tuple[str, str]],
@@ -309,6 +311,7 @@ class ASRAsyncService(ASRService):
             finally:
                 task_to_run[f"{task_type}_done"].set()
 
+    @time_and_tell
     def process_transcription(
         self, task: dict
     ) -> Union[List[dict], Tuple[List[dict], List[dict]]]:
@@ -357,6 +360,7 @@ class ASRAsyncService(ASRService):
         else:
             raise ValueError(f"Invalid input type: {type(task['input'])}")
 
+    @time_and_tell
     def process_diarization(self, task: dict) -> List[dict]:
         """
         Process a task of diarization.
@@ -371,6 +375,7 @@ class ASRAsyncService(ASRService):
 
         return utterances
 
+    @time_and_tell
     def process_alignment(self, task: dict) -> List[dict]:
         """
         Process a task of alignment.
@@ -389,6 +394,7 @@ class ASRAsyncService(ASRService):
 
         return segments
 
+    @time_and_tell
     def process_post_processing(self, task: dict) -> List[dict]:
         """
         Process a task of post processing.
@@ -445,6 +451,7 @@ class ASRAsyncService(ASRService):
 
         return final_utterances
 
+    @time_and_tell
     def transcribe_dual_channel(
         self,
         source_lang: str,

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -278,15 +278,6 @@ class ASRAsyncService(ASRService):
                 self.needs_processing_timer[task_type] = None
 
             async with self.queue_locks[task_type]:
-                if self.queues[task_type]:
-                    longest_wait = (
-                        asyncio.get_event_loop().time()
-                        - self.queues[task_type][0]["time"]
-                    )
-                    logger.debug(f"[{task_type}] longest wait: {longest_wait}")
-                else:
-                    longest_wait = None
-
                 task_to_run = self.queues[task_type][0]
                 del self.queues[task_type][0]
 

--- a/wordcab_transcribe/services/diarize_service.py
+++ b/wordcab_transcribe/services/diarize_service.py
@@ -20,6 +20,7 @@ import librosa
 import soundfile as sf
 from nemo.collections.asr.models.msdd_models import NeuralDiarizer
 
+from wordcab_transcribe.logging import time_and_tell
 from wordcab_transcribe.utils import load_nemo_config
 
 
@@ -52,6 +53,7 @@ class DiarizeService:
             )
         ).to(device)
 
+    @time_and_tell
     def __call__(self, filepath: str) -> List[dict]:
         """
         Run inference with the diarization model.

--- a/wordcab_transcribe/services/transcribe_service.py
+++ b/wordcab_transcribe/services/transcribe_service.py
@@ -22,7 +22,6 @@ import numpy as np
 import torch
 import torch.nn.functional as F  # noqa N812
 import torchaudio
-from ctranslate2 import StorageView
 from ctranslate2.models import WhisperGenerationResult
 from faster_whisper import WhisperModel
 from faster_whisper.tokenizer import Tokenizer

--- a/wordcab_transcribe/services/transcribe_service.py
+++ b/wordcab_transcribe/services/transcribe_service.py
@@ -31,7 +31,10 @@ from faster_whisper.transcribe import (
     get_ctranslate2_storage,
     get_suppressed_tokens,
 )
+from loguru import logger
 from torch.utils.data import DataLoader, IterableDataset
+
+from wordcab_transcribe.logging import time_and_tell
 
 
 # Word implementation from faster-whisper:
@@ -109,6 +112,7 @@ class AudioDataset(IterableDataset):
 
         return wav.squeeze(0)
 
+    @time_and_tell
     def create_chunks(
         self, waveform: torch.Tensor
     ) -> Tuple[List[torch.Tensor], List[int], List[float]]:
@@ -204,7 +208,7 @@ class TranscribeService:
             language="en",  # Default language, to gain some speed
         )
 
-        self._batch_size = 32  # TODO: Make this configurable
+        self._batch_size = 8  # TODO: Make this configurable
         self.sample_rate = 16000
 
         self.n_fft = 400
@@ -272,6 +276,7 @@ class TranscribeService:
 
         return outputs
 
+    @time_and_tell
     def pipeline(
         self,
         audio: Union[str, torch.Tensor],
@@ -319,6 +324,7 @@ class TranscribeService:
 
     # This is an adapted version of the faster-whisper transcription pipeline:
     # https://github.com/guillaumekln/faster-whisper/blob/master/faster_whisper/transcribe.py
+    @time_and_tell
     def _generate_segment_batched(
         self,
         features: torch.Tensor,
@@ -340,9 +346,11 @@ class TranscribeService:
         Returns:
             List[dict]: List of segments with the following keys: "start", "end", "text", "confidence".
         """
-        batch_size = features.size(0)
         if "TOKENIZERS_PARALLELISM" not in os.environ:
             os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+        batch_size = features.size(0)
+        logger.debug(f"Batch size: {batch_size}")
 
         all_tokens = []
         prompt_reset_since = 0
@@ -360,7 +368,7 @@ class TranscribeService:
             prefix=options.prefix,
         )
 
-        features = self._encode(features)
+        features = get_ctranslate2_storage(features)
 
         # TODO: Could be better to get the results as np.ndarray/torch.tensor and not as a class for speed
         # Atm, we need to extract the results as a Python list which is slow because we get this results:
@@ -470,29 +478,6 @@ class TranscribeService:
         decoded_outputs = self._decode_batch(outputs)
 
         return decoded_outputs
-
-    def _encode(self, features: torch.Tensor) -> StorageView:
-        """
-        Encode a batch of features using the ctranslate2 Whisper model.
-
-        Args:
-            features (torch.Tensor): Batch of features.
-
-        Returns:
-            StorageView: Encoded features.
-        """
-        # TODO: We call the inherited model here, because faster_whisper model does not allow to
-        # access the device and the device_index. We should fix this in the future.
-        to_cpu = (
-            self.model.model.device == "cuda" and len(self.model.model.device_index) > 1
-        )
-
-        if len(features.shape) == 2:
-            features = np.expand_dims(features, 0)
-
-        features = get_ctranslate2_storage(features)
-
-        return self.model.model.encode(features, to_cpu=to_cpu)
 
     def _decode_batch(self, outputs: List[dict]) -> List[dict]:
         """


### PR DESCRIPTION
This PR adds logging + time execution monitoring

The monitoring process is activated **ONLY** if `debug=True`. It's deactivated otherwise to avoid extra computation time in prod.

* Add a LoggingMiddleware for all the endpoints -> display the method and then the response status + process time
* Add a decorator to time individual functions in the app (transcription, diarization, and alignment)
* Fix transcription batch_size to 8