### PR TITLE
Add dual channel fallback

### DIFF
--- a/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -67,7 +67,14 @@ async def inference_with_audio(
     )
 
     if data.dual_channel:
-        filepath = await split_dual_channel_file(filepath=filename)
+        try:
+            filepath = await split_dual_channel_file(filename)
+        except Exception as e:
+            logger.error(f"{e}\nFallback to single channel mode.")
+
+            data.dual_channel = False
+            filepath = await convert_file_to_wav(filename)
+
     else:
         filepath = await convert_file_to_wav(filepath=filename)
 

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -45,19 +45,19 @@ async def inference_with_audio_url(
 
     data = AudioRequest() if data is None else AudioRequest(**data.dict())
 
-    filepath, extension = await download_audio_file(url, filename)
+    _filepath, extension = await download_audio_file(url, filename)
 
     if data.dual_channel:
         try:
-            filepath = await split_dual_channel_file(filepath)
+            filepath = await split_dual_channel_file(_filepath)
         except Exception as e:
             logger.error(f"{e}\nFallback to single channel mode.")
 
             data.dual_channel = False
-            filepath = await convert_file_to_wav(filepath)
+            filepath = await convert_file_to_wav(_filepath)
 
     else:
-        filepath = await convert_file_to_wav(filepath)
+        filepath = await convert_file_to_wav(_filepath)
 
     background_tasks.add_task(delete_file, filepath=f"{filename}.{extension}")
 

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -48,7 +48,14 @@ async def inference_with_audio_url(
     filepath, extension = await download_audio_file(url, filename)
 
     if data.dual_channel:
-        filepath = await split_dual_channel_file(filepath)
+        try:
+            filepath = await split_dual_channel_file(filepath)
+        except Exception as e:
+            logger.error(f"{e}\nFallback to single channel mode.")
+
+            data.dual_channel = False
+            filepath = await convert_file_to_wav(filepath)
+            
     else:
         filepath = await convert_file_to_wav(filepath)
 

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -55,7 +55,7 @@ async def inference_with_audio_url(
 
             data.dual_channel = False
             filepath = await convert_file_to_wav(filepath)
-            
+
     else:
         filepath = await convert_file_to_wav(filepath)
 


### PR DESCRIPTION
This PR:
* Adds a `dual_channel` fallback if audio isn't stereo
* Rename the intermediary `filepath` to `_filepath` to avoid confusion in the `audio_url` endpoint.