### PR TITLE
Add batching to dual_channel

### DIFF
--- a/wordcab_transcribe/services/vad_service.py
+++ b/wordcab_transcribe/services/vad_service.py
@@ -29,7 +29,7 @@ class VadService:
         self.options = VadOptions(
             threshold=0.5,
             min_speech_duration_ms=250,
-            max_speech_duration_s=float("inf"),
+            max_speech_duration_s=30,
             min_silence_duration_ms=100,
             window_size_samples=512,
             speech_pad_ms=30,


### PR DESCRIPTION
This PR:
* Update the `dual_channel` process to use batch requests efficiently.
* Introduce a group_index in the AudioDataset for `dual_channel`, None otherwise.
* Fix the VAD parameter to get maximum 30 seconds segments.