### PR TITLE
Add extra models for specific languages

### DIFF
--- a/.env
+++ b/.env
@@ -46,6 +46,9 @@ WHISPER_MODEL="large-v2"
 # "int8", "int8_float16", "int16", "float_16". The default value is "int8_float16", which is the fastest option with
 # minimal loss in accuracy using the `large-v2` model.
 COMPUTE_TYPE="float16"
+# The extra_languages parameter is used to control the languages that need an extra model to be loaded.
+# You can specify multiple languages separated by a comma. The available languages are: `he` (Hebrew).
+EXTRA_LANGUAGES="he"
 #
 # --------------------------------------------------- NVIDIA NEMO ---------------------------------------------------- #
 #
@@ -104,7 +107,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES=30
 # ---------------------------------------------- CORTEX CONFIGURATION ------------------------------------------------ #
 #
 # The cortex_api_key parameter is used to control the API key used to authenticate the requests to the cortex endpoint.
-WORDCAB_TRANSCRIBE_API_KEY=
+WORDCAB_TRANSCRIBE_API_KEY="test"
 #
 # ----------------------------------------------- SVIX CONFIGURATION ------------------------------------------------- #
 #

--- a/.env
+++ b/.env
@@ -107,7 +107,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES=30
 # ---------------------------------------------- CORTEX CONFIGURATION ------------------------------------------------ #
 #
 # The cortex_api_key parameter is used to control the API key used to authenticate the requests to the cortex endpoint.
-WORDCAB_TRANSCRIBE_API_KEY="test"
+WORDCAB_TRANSCRIBE_API_KEY=""
 #
 # ----------------------------------------------- SVIX CONFIGURATION ------------------------------------------------- #
 #

--- a/.env
+++ b/.env
@@ -107,7 +107,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES=30
 # ---------------------------------------------- CORTEX CONFIGURATION ------------------------------------------------ #
 #
 # The cortex_api_key parameter is used to control the API key used to authenticate the requests to the cortex endpoint.
-WORDCAB_TRANSCRIBE_API_KEY=""
+WORDCAB_TRANSCRIBE_API_KEY=
 #
 # ----------------------------------------------- SVIX CONFIGURATION ------------------------------------------------- #
 #

--- a/convert_whisper_model.py
+++ b/convert_whisper_model.py
@@ -1,0 +1,72 @@
+# This script converts a whisper model to a ctranslate2 model.
+# Use this script to convert a model from the HuggingFace Hub to a ctranslate2 model.
+# E.g. `python convert_whisper_model.py -p openai/whisper-large-v2 -o whisper-large-v2 -q int8_float16`
+#
+# The script requires the following dependencies:
+# - ctranslate2
+# - transformers[torch]
+
+import argparse
+import importlib
+import subprocess
+
+def check_dependency(module_name: str) -> None:
+    """
+    Check if a module is installed. If not, exit with an error message.
+
+    Args:
+        module_name (str): Name of the module to check.
+    """
+    try:
+        importlib.import_module(module_name)
+
+    except ImportError:
+        print(f"Error: '{module_name}' module not found. Please make sure it is installed and try again.")
+        exit(1)
+
+
+if __name__ == "__main__":
+    check_dependency("ctranslate2")
+    check_dependency("transformers")
+    
+    parser = argparse.ArgumentParser(description="Convert a whisper model to ctranslate2")
+
+    parser.add_argument("-p", "--model_path", type=str, help="Path to the whisper model stored on the HuggingFace Hub.")
+    parser.add_argument("-o", "--output_path", type=str, help="Path to the output directory.")
+    parser.add_argument(
+        "-q", "--quantization",
+        default=None,
+        type=str,
+        help="Quantization type. Can be 'int8', 'int8_float16', 'int16' or 'float16'."
+    )
+
+    args = parser.parse_args()
+
+    # Check if the quantization type is valid.
+    if args.quantization and args.quantization not in ["int8", "int8_float16", "int16", "float16"]:
+        print(
+            f"Error: '{args.quantization}' is not a valid quantization type."
+            "Please choose between 'int8', 'int8_float16', 'int16' or 'float16'."
+            "If you don't want to quantize the model, don't use the '-q' option."
+        )
+        exit(1)
+
+    command = [
+        "ct2-transformers-converter",
+        "--model",
+        args.model_path,
+        "--output_dir",
+        args.output_path,
+    ]
+    if args.quantization:
+        command.extend(["--quantization", args.quantization])
+
+    
+    process = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
+    stdout, stderr = process.communicate()
+
+    if process.returncode != 0:
+        print(f"Error: {stderr.decode('utf-8')}")
+        exit(1)

--- a/convert_whisper_model.py
+++ b/convert_whisper_model.py
@@ -5,10 +5,12 @@
 # The script requires the following dependencies:
 # - ctranslate2
 # - transformers[torch]
+"""Convert a whisper model to ctranslate2."""
 
 import argparse
 import importlib
-import subprocess
+import subprocess  # noqa: S404
+
 
 def check_dependency(module_name: str) -> None:
     """
@@ -21,31 +23,48 @@ def check_dependency(module_name: str) -> None:
         importlib.import_module(module_name)
 
     except ImportError:
-        print(f"Error: '{module_name}' module not found. Please make sure it is installed and try again.")
+        print(
+            f"Error: {module_name} module not found. Please make sure it is installed and try again."
+        )
         exit(1)
 
 
 if __name__ == "__main__":
     check_dependency("ctranslate2")
     check_dependency("transformers")
-    
-    parser = argparse.ArgumentParser(description="Convert a whisper model to ctranslate2")
 
-    parser.add_argument("-p", "--model_path", type=str, help="Path to the whisper model stored on the HuggingFace Hub.")
-    parser.add_argument("-o", "--output_path", type=str, help="Path to the output directory.")
+    parser = argparse.ArgumentParser(
+        description="Convert a whisper model to ctranslate2"
+    )
+
     parser.add_argument(
-        "-q", "--quantization",
+        "-p",
+        "--model_path",
+        type=str,
+        help="Path to the whisper model stored on the HuggingFace Hub.",
+    )
+    parser.add_argument(
+        "-o", "--output_path", type=str, help="Path to the output directory."
+    )
+    parser.add_argument(
+        "-q",
+        "--quantization",
         default=None,
         type=str,
-        help="Quantization type. Can be 'int8', 'int8_float16', 'int16' or 'float16'."
+        help="Quantization type. Can be 'int8', 'int8_float16', 'int16' or 'float16'.",
     )
 
     args = parser.parse_args()
 
     # Check if the quantization type is valid.
-    if args.quantization and args.quantization not in ["int8", "int8_float16", "int16", "float16"]:
+    if args.quantization and args.quantization not in [
+        "int8",
+        "int8_float16",
+        "int16",
+        "float16",
+    ]:
         print(
-            f"Error: '{args.quantization}' is not a valid quantization type."
+            f"Error: {args.quantization} is not a valid quantization type."
             "Please choose between 'int8', 'int8_float16', 'int16' or 'float16'."
             "If you don't want to quantize the model, don't use the '-q' option."
         )
@@ -61,8 +80,7 @@ if __name__ == "__main__":
     if args.quantization:
         command.extend(["--quantization", args.quantization])
 
-    
-    process = subprocess.Popen(
+    process = subprocess.Popen(  # noqa: S603,S607
         command, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
     stdout, stderr = process.communicate()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,7 +72,7 @@ def test_config() -> None:
     assert settings.whisper_model == "large-v2"
     assert settings.compute_type == "float16"
     assert settings.extra_languages == ["he"]
-    assert settings.extra_languages_model_paths == {"he": "path/to/model"}
+    assert settings.extra_languages_model_paths == {"he": ""}
 
     assert settings.nemo_domain_type == "telephonic"
     assert settings.nemo_storage_path == "nemo_storage"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -33,6 +33,7 @@ def default_settings() -> OrderedDict:
         max_wait=0.1,
         whisper_model="large-v2",
         compute_type="float16",
+        extra_languages=["he"],
         nemo_domain_type="general",
         nemo_storage_path="nemo_storage",
         nemo_output_path="nemo_outputs",
@@ -66,8 +67,11 @@ def test_config() -> None:
 
     assert settings.batch_size == 1
     assert settings.max_wait == 0.1
+
     assert settings.whisper_model == "large-v2"
     assert settings.compute_type == "float16"
+    assert settings.extra_languages == ["he"]
+
     assert settings.nemo_domain_type == "telephonic"
     assert settings.nemo_storage_path == "nemo_storage"
     assert settings.nemo_output_path == "nemo_outputs"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,6 +34,7 @@ def default_settings() -> OrderedDict:
         whisper_model="large-v2",
         compute_type="float16",
         extra_languages=["he"],
+        extra_languages_model_paths={"he": "path/to/model"},
         nemo_domain_type="general",
         nemo_storage_path="nemo_storage",
         nemo_output_path="nemo_outputs",
@@ -71,6 +72,7 @@ def test_config() -> None:
     assert settings.whisper_model == "large-v2"
     assert settings.compute_type == "float16"
     assert settings.extra_languages == ["he"]
+    assert settings.extra_languages_model_paths == {"he": "path/to/model"}
 
     assert settings.nemo_domain_type == "telephonic"
     assert settings.nemo_storage_path == "nemo_storage"

--- a/wordcab_transcribe/config.py
+++ b/wordcab_transcribe/config.py
@@ -15,7 +15,7 @@
 
 from os import getenv
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 from dotenv import load_dotenv
 from faster_whisper.utils import _MODELS
@@ -41,6 +41,7 @@ class Settings:
     # Whisper
     whisper_model: str
     compute_type: str
+    extra_languages: List[str]
     # NVIDIA NeMo
     nemo_domain_type: str
     nemo_storage_path: str
@@ -174,6 +175,12 @@ class Settings:
 
 load_dotenv()
 
+# Extra languages
+_extra_languages = getenv("EXTRA_LANGUAGES")
+if _extra_languages is not None:
+    extra_languages = _extra_languages.split(",")
+else:
+    extra_languages = []
 
 settings = Settings(
     # General configuration
@@ -191,6 +198,7 @@ settings = Settings(
     # Whisper
     whisper_model=getenv("WHISPER_MODEL", "large-v2"),
     compute_type=getenv("COMPUTE_TYPE", "int8_float16"),
+    extra_languages=extra_languages,
     # NeMo
     nemo_domain_type=getenv("NEMO_DOMAIN_TYPE", "general"),
     nemo_storage_path=getenv("NEMO_STORAGE_PATH", "nemo_storage"),

--- a/wordcab_transcribe/config.py
+++ b/wordcab_transcribe/config.py
@@ -15,7 +15,7 @@
 
 from os import getenv
 from pathlib import Path
-from typing import List, Union
+from typing import Dict, List, Union
 
 from dotenv import load_dotenv
 from faster_whisper.utils import _MODELS
@@ -42,6 +42,7 @@ class Settings:
     whisper_model: str
     compute_type: str
     extra_languages: List[str]
+    extra_languages_model_paths: Dict[str, str]
     # NVIDIA NeMo
     nemo_domain_type: str
     nemo_storage_path: str
@@ -199,6 +200,7 @@ settings = Settings(
     whisper_model=getenv("WHISPER_MODEL", "large-v2"),
     compute_type=getenv("COMPUTE_TYPE", "int8_float16"),
     extra_languages=extra_languages,
+    extra_languages_model_paths={lang: "" for lang in extra_languages},
     # NeMo
     nemo_domain_type=getenv("NEMO_DOMAIN_TYPE", "general"),
     nemo_storage_path=getenv("NEMO_STORAGE_PATH", "nemo_storage"),

--- a/wordcab_transcribe/main.py
+++ b/wordcab_transcribe/main.py
@@ -30,7 +30,7 @@ from wordcab_transcribe.router.v1.endpoints import (
     auth_router,
     cortex_router,
 )
-from wordcab_transcribe.utils import retrieve_user_platform
+from wordcab_transcribe.utils import download_model, retrieve_user_platform
 
 
 # Main application instance creation
@@ -68,6 +68,14 @@ async def startup_event():
             "The application was tested on Ubuntu 22.04, so we cannot guarantee that it will work on other OS.\n"
             "Report any issues with your env specs to: https://github.com/Wordcab/wordcab-transcribe/issues"
         )
+
+    if settings.extra_languages:
+        logger.info("Downloading models for extra languages...")
+        for model in settings.extra_languages:
+            try:
+                download_model(compute_type=settings.compute_type, language=model)
+            except Exception as e:
+                logger.error(f"Error downloading model for {model}: {e}")
 
     if settings.asr_type == "async":
         task_names = asr.queues.keys()

--- a/wordcab_transcribe/main.py
+++ b/wordcab_transcribe/main.py
@@ -73,7 +73,15 @@ async def startup_event():
         logger.info("Downloading models for extra languages...")
         for model in settings.extra_languages:
             try:
-                download_model(compute_type=settings.compute_type, language=model)
+                model_path = download_model(
+                    compute_type=settings.compute_type, language=model
+                )
+
+                if model_path is not None:
+                    settings.extra_languages_model_paths[model] = model_path
+                else:
+                    raise Exception(f"Coudn't download model for {model}")
+
             except Exception as e:
                 logger.error(f"Error downloading model for {model}: {e}")
 

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -334,7 +334,7 @@ async def download_audio_file(
 
 
 # pragma: no cover
-def download_model(compute_type: str, language: str) -> None:
+def download_model(compute_type: str, language: str) -> Optional[str]:
     """
     Download the special models during the warmup phase.
 
@@ -343,7 +343,7 @@ def download_model(compute_type: str, language: str) -> None:
         language (str): The target language.
 
     Returns:
-        None
+        Optional[str]: The path to the downloaded model.
     """
     if compute_type == "float16":
         repo_id = f"wordcab/whisper-large-fp16-{language}"
@@ -355,12 +355,12 @@ def download_model(compute_type: str, language: str) -> None:
         # No other models are supported
         return None
 
-    allow_patterns = ["config.json", "model.bin", "vocabulary.*"]
-    huggingface_hub.snapshot_download(
+    allow_patterns = ["config.json", "model.bin", "tokenizer.json", "vocabulary.*"]
+    snapshot_path = huggingface_hub.snapshot_download(
         repo_id, local_files_only=False, allow_patterns=allow_patterns
     )
 
-    return None
+    return snapshot_path
 
 
 def delete_file(filepath: Union[str, Tuple[str, Optional[str]]]) -> None:

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 import aiofiles
 import aiohttp
 import filetype
+import huggingface_hub
 import pandas as pd
 import torch
 import torchaudio
@@ -330,6 +331,36 @@ async def download_audio_file(
                 raise Exception(f"Failed to download file. Status: {response.status}")
 
     return filename, extension
+
+
+# pragma: no cover
+def download_model(compute_type: str, language: str) -> None:
+    """
+    Download the special models during the warmup phase.
+
+    Args:
+        compute_type (str): The target compute type.
+        language (str): The target language.
+
+    Returns:
+        None
+    """
+    if compute_type == "float16":
+        repo_id = f"wordcab/whisper-large-fp16-{language}"
+    elif compute_type == "int8_float16":
+        repo_id = f"wordcab/whisper-large-int8-fp16-{language}"
+    elif compute_type == "int8":
+        repo_id = f"wordcab/whisper-large-int8-{language}"
+    else:
+        # No other models are supported
+        return None
+
+    allow_patterns = ["config.json", "model.bin", "vocabulary.*"]
+    huggingface_hub.snapshot_download(
+        repo_id, local_files_only=False, allow_patterns=allow_patterns
+    )
+
+    return None
 
 
 def delete_file(filepath: Union[str, Tuple[str, Optional[str]]]) -> None:


### PR DESCRIPTION
This PR introduces a convenient way to add extra models for specific languages.

By separating them with a comma, you add the language code to the `.env` file under the `EXTRA_LANGUAGES` key.

The languages will then be downloaded from the wordcab HF org, and the snapshot path will be added to the `settings.extra_languages_model_path` for later reference.

The appropriate model is loaded before anything if the `source_lang` is an extra language during inference.