### PR TITLE
Add `audio_duration` key in API response

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -50,6 +50,7 @@ def test_audio_response() -> None:
     """Test the AudioResponse model."""
     response = AudioResponse(
         utterances=[],
+        audio_duration=0.0,
         alignment=False,
         diarization=False,
         dual_channel=False,
@@ -59,6 +60,7 @@ def test_audio_response() -> None:
         word_timestamps=False,
     )
     assert response.utterances == []
+    assert response.audio_duration == 0.0
     assert response.alignment is False
     assert response.diarization is False
     assert response.dual_channel is False
@@ -72,6 +74,7 @@ def test_audio_response() -> None:
             {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
             {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
         ],
+        audio_duration=6.0,
         alignment=True,
         diarization=True,
         dual_channel=True,
@@ -84,6 +87,7 @@ def test_audio_response() -> None:
         {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
         {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
     ]
+    assert response.audio_duration == 6.0
     assert response.alignment is True
     assert response.diarization is True
     assert response.dual_channel is True
@@ -130,6 +134,7 @@ def test_base_response() -> None:
             {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
             {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
         ],
+        audio_duration=6.0,
         alignment=True,
         diarization=False,
         source_lang="en",
@@ -141,6 +146,7 @@ def test_base_response() -> None:
         {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
         {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
     ]
+    assert response.audio_duration == 6.0
     assert response.alignment is True
     assert response.diarization is False
     assert response.source_lang == "en"
@@ -194,6 +200,7 @@ def test_cortex_url_response() -> None:
             {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
             {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
         ],
+        audio_duration=6.0,
         alignment=True,
         diarization=False,
         source_lang="en",
@@ -208,6 +215,7 @@ def test_cortex_url_response() -> None:
         {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
         {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
     ]
+    assert response.audio_duration == 6.0
     assert response.alignment is True
     assert response.diarization is False
     assert response.source_lang == "en"
@@ -226,6 +234,7 @@ def test_cortex_youtube_response() -> None:
             {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
             {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
         ],
+        audio_duration=6.0,
         alignment=True,
         diarization=False,
         source_lang="en",
@@ -240,6 +249,7 @@ def test_cortex_youtube_response() -> None:
         {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
         {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
     ]
+    assert response.audio_duration == 6.0
     assert response.alignment is True
     assert response.diarization is False
     assert response.source_lang == "en"
@@ -258,6 +268,7 @@ def test_youtube_response() -> None:
             {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
             {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
         ],
+        audio_duration=6.0,
         alignment=True,
         diarization=False,
         source_lang="en",
@@ -270,6 +281,7 @@ def test_youtube_response() -> None:
         {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
         {"text": "Never gonna let you down", "start": 3.0, "end": 6.0},
     ]
+    assert response.audio_duration == 6.0
     assert response.alignment is True
     assert response.diarization is False
     assert response.source_lang == "en"

--- a/wordcab_transcribe/models.py
+++ b/wordcab_transcribe/models.py
@@ -22,6 +22,7 @@ class BaseResponse(BaseModel):
     """Base response model, not meant to be used directly."""
 
     utterances: List[dict]
+    audio_duration: float
     alignment: bool
     diarization: bool
     source_lang: str
@@ -54,6 +55,7 @@ class AudioResponse(BaseResponse):
                         "speaker": 1,
                     },
                 ],
+                "audio_duration": 2.678,
                 "alignment": False,
                 "diarization": False,
                 "source_lang": "en",
@@ -89,6 +91,7 @@ class YouTubeResponse(BaseResponse):
                         "text": "Never gonna let you down!",
                     },
                 ],
+                "audio_duration": 2.0,
                 "alignment": False,
                 "diarization": False,
                 "source_lang": "en",
@@ -191,6 +194,7 @@ class CortexUrlResponse(AudioResponse):
                         "text": "Wordcab is awesome",
                     },
                 ],
+                "audio_duration": 2.0,
                 "alignment": False,
                 "diariation": False,
                 "source_lang": "en",
@@ -229,6 +233,7 @@ class CortexYoutubeResponse(YouTubeResponse):
                         "text": "Never gonna let you down!",
                     },
                 ],
+                "audio_duration": 2.0,
                 "alignment": False,
                 "diariation": False,
                 "source_lang": "en",

--- a/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -112,6 +112,7 @@ async def inference_with_audio(
     else:
         return AudioResponse(
             utterances=utterances,
+            audio_duration=audio_duration,
             alignment=data.alignment,
             diarization=data.diarization,
             dual_channel=data.dual_channel,

--- a/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -75,14 +75,15 @@ async def inference_with_audio(
             logger.error(f"{e}\nFallback to single channel mode.")
             data.dual_channel = False
 
-    try:
-        filepath = await convert_file_to_wav(filename)
+    if not data.dual_channel:
+        try:
+            filepath = await convert_file_to_wav(filename)
 
-    except Exception as e:
-        raise HTTPException(  # noqa: B904
-            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Process failed: {e}",
-        )
+        except Exception as e:
+            raise HTTPException(  # noqa: B904
+                status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Process failed: {e}",
+            )
 
     background_tasks.add_task(delete_file, filepath=filename)
 
@@ -98,7 +99,7 @@ async def inference_with_audio(
             word_timestamps=data.word_timestamps,
         )
     )
-    utterances = await task
+    utterances, audio_duration = await task
 
     background_tasks.add_task(delete_file, filepath=filepath)
 

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -54,14 +54,15 @@ async def inference_with_audio_url(
             logger.error(f"{e}\nFallback to single channel mode.")
             data.dual_channel = False
 
-    try:
-        filepath = await convert_file_to_wav(_filepath)
+    if not data.dual_channel:
+        try:
+            filepath = await convert_file_to_wav(_filepath)
 
-    except Exception as e:
-        raise HTTPException(  # noqa: B904
-            status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Process failed: {e}",
-        )
+        except Exception as e:
+            raise HTTPException(  # noqa: B904
+                status_code=http_status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"Process failed: {e}",
+            )
 
     background_tasks.add_task(delete_file, filepath=filename)
 
@@ -77,7 +78,7 @@ async def inference_with_audio_url(
             word_timestamps=data.word_timestamps,
         )
     )
-    utterances = await task
+    utterances, audio_duration = await task
 
     background_tasks.add_task(delete_file, filepath=filepath)
 

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -91,6 +91,7 @@ async def inference_with_audio_url(
     else:
         return AudioResponse(
             utterances=utterances,
+            audio_duration=audio_duration,
             alignment=data.alignment,
             diarization=data.diarization,
             dual_channel=data.dual_channel,

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -68,6 +68,7 @@ async def inference_with_youtube(
     else:
         return YouTubeResponse(
             utterances=utterances,
+            audio_duration=audio_duration,
             alignment=data.alignment,
             diarization=data.diarization,
             source_lang=data.source_lang,

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -55,7 +55,7 @@ async def inference_with_youtube(
             word_timestamps=data.word_timestamps,
         )
     )
-    utterances = await task
+    utterances, audio_duration = await task
 
     background_tasks.add_task(delete_file, filepath=filepath)
 

--- a/wordcab_transcribe/services/align_service.py
+++ b/wordcab_transcribe/services/align_service.py
@@ -254,7 +254,7 @@ class AlignService:
         transcript: Iterator[SingleSegment],
         model: torch.nn.Module,
         align_model_metadata: dict,
-        audio_path: str,
+        audio_path: Union[str, torch.Tensor],
         device: str,
         interpolate_method: Optional[str] = "nearest",
         return_char_alignments: Optional[bool] = False,
@@ -278,7 +278,11 @@ class AlignService:
         Raises:
             NotImplementedError: If the model type is not implemented.
         """
-        audio, sample_rate = torchaudio.load(audio_path, normalize=True)
+        if isinstance(audio_path, str):
+            audio, sample_rate = torchaudio.load(audio_path, normalize=True)
+        else:
+            audio = audio_path
+            sample_rate = self.sample_rate
 
         if len(audio.shape) == 1:
             audio = audio.unsqueeze(0)

--- a/wordcab_transcribe/services/transcribe_service.py
+++ b/wordcab_transcribe/services/transcribe_service.py
@@ -140,7 +140,15 @@ class AudioDataset(IterableDataset):
             }
 
     def read_audio(self, filepath: str) -> torch.Tensor:
-        """Read an audio file and return the audio tensor."""
+        """
+        Read an audio file and return the audio tensor.
+
+        Args:
+            filepath (str): Path to the audio file.
+
+        Returns:
+            torch.Tensor: Audio tensor.
+        """
         wav, sr = torchaudio.load(filepath)
 
         if wav.size(0) > 1:
@@ -319,7 +327,9 @@ class TranscribeService:
 
     def __call__(
         self,
-        audio: Union[str, torch.Tensor, Tuple[str, str]],
+        audio: Union[
+            str, torch.Tensor, Tuple[str, str], Tuple[torch.Tensor, torch.Tensor]
+        ],
         source_lang: str,
         suppress_blank: bool = False,
         word_timestamps: bool = True,
@@ -330,9 +340,9 @@ class TranscribeService:
         Run inference with the transcribe model.
 
         Args:
-            audio (Union[str, torch.Tensor, Tuple[str, str]]): Audio file path or audio tensor. If a tuple is passed,
-                the task is assumed to be a dual_channel task and the tuple should contain the paths to the two
-                audio files.
+            audio (Union[str, torch.Tensor, Tuple[str, str], Tuple[torch.Tensor, torch.Tensor]]): Audio file path or
+                audio tensor. If a tuple is passed, the task is assumed to be a dual_channel task and the tuple should
+                contain the paths to the two audio files.
             source_lang (str): Language of the audio file.
             suppress_blank (bool): Whether to suppress blank at the beginning of the sampling.
             word_timestamps (bool): Whether to return word timestamps.
@@ -364,7 +374,10 @@ class TranscribeService:
             )
             self.loaded_model_lang = "multi"
 
-        if not use_batch:
+        if not use_batch and not isinstance(audio, tuple):
+            if isinstance(audio, torch.Tensor):
+                audio = audio.numpy()
+
             segments, _ = self.model.transcribe(
                 audio,
                 language=source_lang,


### PR DESCRIPTION
This PR:
* Add `audio_duration` keyword to monitor audio duration transcribed
* Fix #75 by reading the audio file once
* Fix a bug introduced by #122  for `dual_channel`