### PR TITLE
130 contributing cannot be done with current instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,14 +192,19 @@ poetry run uvicorn wordcab_transcribe.main:app --reload
 
 ### Getting started
 
-1. Clone the repo
+1. Ensure you have the following tools :
+
+- [poetry](https://python-poetry.org/)
+- [nox](https://nox.thea.codes/) and [nox-poetry](https://nox-poetry.readthedocs.io/)
+
+2. Clone the repo
 
 ```bash
 git clone
 cd wordcab-transcribe
 ```
 
-2. Install dependencies and start coding
+3. Install dependencies and start coding
 
 ```bash
 poetry install
@@ -212,7 +217,7 @@ nox --session=pre-commit -- install
 code .
 ```
 
-3. Run tests
+4. Run tests
 
 ```bash
 # run all tests

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ poetry run uvicorn wordcab_transcribe.main:app --reload
 
 ```bash
 git clone
-cd wordcab-ask
+cd wordcab-transcribe
 ```
 
 2. Install dependencies and start coding

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ cd wordcab-transcribe
 3. Install dependencies and start coding
 
 ```bash
-poetry install
 poetry shell
+poetry install --no-cache
 
 # install pre-commit hooks
 nox --session=pre-commit -- install


### PR DESCRIPTION
This is a PR that intends to fix https://github.com/Wordcab/wordcab-transcribe/issues/130.
One missing item though : I did not find a proper way to load the  `.env` file during tests.