### PR TITLE
Upgraded docker image to nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.7.0-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Upgraded base docker image to nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04