### PR TITLE
New post-processing strategy

### DIFF
--- a/tests/utils/test_load_nemo_config.py
+++ b/tests/utils/test_load_nemo_config.py
@@ -25,7 +25,11 @@ from wordcab_transcribe.utils import load_nemo_config
 def test_load_nemo_config(domain_type: str):
     """Test the load_nemo_config function."""
     cfg, _ = load_nemo_config(
-        domain_type, "storage/path", "output/path", "cpu", 0,
+        domain_type,
+        "storage/path",
+        "output/path",
+        "cpu",
+        0,
     )
 
     cfg_path = f"config/nemo/diar_infer_{domain_type}.yaml"

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -225,6 +225,9 @@ class ASRAsyncService(ASRService):
 
         await task["post_processing_done"].wait()
 
+        if isinstance(task["post_processing_result"], Exception):
+            return task["post_processing_result"]
+
         result = task.pop("post_processing_result")
         del task  # Delete the task to free up memory
 

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -156,6 +156,7 @@ class ASRAsyncService(ASRService):
         else:
             audio, duration = read_audio(filepath)
 
+        alignment = False  # New strategy doesn't require alignment for now
         task = {
             "input": audio,
             "alignment": alignment,
@@ -359,7 +360,7 @@ class ASRAsyncService(ASRService):
                     segments=segments,
                     alignment=alignment,
                     use_batch=task["use_batch"],
-                    word_timestamps=word_timestamps,
+                    word_timestamps=True,
                 )
 
                 if diarization:

--- a/wordcab_transcribe/services/post_processing_service.py
+++ b/wordcab_transcribe/services/post_processing_service.py
@@ -14,11 +14,10 @@
 """Post-Processing Service for audio files."""
 
 from typing import Any, Dict, List
-from loguru import logger
 
 from wordcab_transcribe.utils import (
-    _convert_s_to_ms,
     _convert_ms_to_s,
+    _convert_s_to_ms,
     convert_timestamp,
     format_punct,
     get_segment_timestamp_anchor,
@@ -54,7 +53,8 @@ class PostProcessingService:
             List[dict]: List of sentences with speaker mapping.
         """
         words_with_speaker_mapping = self.words_speaker_mapping(
-            transcript_segments, speaker_timestamps,
+            transcript_segments,
+            speaker_timestamps,
         )
 
         utterances = self.reconstruct_utterances(
@@ -112,7 +112,9 @@ class PostProcessingService:
 
         mapped_words = []
         for word in all_words:
-            word_start, word_end = _convert_s_to_ms(word["start"]), _convert_s_to_ms(word["end"])
+            word_start, word_end = _convert_s_to_ms(word["start"]), _convert_s_to_ms(
+                word["end"]
+            )
             while word_start > float(end):
                 turn_idx += 1
                 turn_idx = min(turn_idx, len(speaker_timestamps) - 1)

--- a/wordcab_transcribe/services/post_processing_service.py
+++ b/wordcab_transcribe/services/post_processing_service.py
@@ -84,7 +84,7 @@ class PostProcessingService:
             List[dict]: List of sentences with speaker mapping.
         """
         utterances = self.merge_segments(left_segments, right_segments)
-        utterances = self.utterances_speaker_mapping(utterances, word_timestamps)
+        utterances = self.reconstruct_utterances(utterances, word_timestamps)
 
         return utterances
 


### PR DESCRIPTION
Adopt a new post-processing strategy for transcription/diarization.
- We now reconstruct utterances based on word timestamps and speaker segments from diarization. We were relying on faster-whisper segments before, which could have been better.
- Fixed `alignment` on False by default to avoid weird behavior until it's proven useful for the new strategy.
- `dual_channel` is still working as previously defined.

Fix #115 and #135 