### PR TITLE
Adding internal_vad parameter which seems to fix output with empty utterances

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -45,6 +45,7 @@ def test_audio_request() -> None:
     assert request.use_batch is False
     assert request.vocab == []
     assert request.word_timestamps is False
+    assert request.internal_vad is False
 
 
 def test_audio_response() -> None:
@@ -60,6 +61,7 @@ def test_audio_response() -> None:
         use_batch=False,
         vocab=["custom company", "custom product"],
         word_timestamps=False,
+        internal_vad=False,
     )
     assert response.utterances == []
     assert response.audio_duration == 0.0
@@ -71,6 +73,7 @@ def test_audio_response() -> None:
     assert response.use_batch is False
     assert response.vocab == ["custom company", "custom product"]
     assert response.word_timestamps is False
+    assert response.internal_vad is False
 
     response = AudioResponse(
         utterances=[
@@ -86,6 +89,7 @@ def test_audio_response() -> None:
         use_batch=False,
         vocab=["custom company", "custom product"],
         word_timestamps=True,
+        internal_vad=False,
     )
     assert response.utterances == [
         {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
@@ -100,6 +104,7 @@ def test_audio_response() -> None:
     assert response.use_batch is False
     assert response.vocab == ["custom company", "custom product"]
     assert response.word_timestamps is True
+    assert response.internal_vad is False
 
 
 def test_base_request_valid() -> None:
@@ -124,6 +129,7 @@ def test_base_request_default() -> None:
     assert req.timestamps == "s"
     assert req.use_batch is False
     assert req.word_timestamps is False
+    assert req.internal_vad is False
 
 
 def test_base_request_invalid() -> None:
@@ -147,6 +153,7 @@ def test_base_response() -> None:
         use_batch=False,
         vocab=["custom company", "custom product"],
         word_timestamps=False,
+        internal_vad=False,
     )
     assert response.utterances == [
         {"text": "Never gonna give you up", "start": 0.0, "end": 3.0},
@@ -160,6 +167,7 @@ def test_base_response() -> None:
     assert response.use_batch is False
     assert response.vocab == ["custom company", "custom product"]
     assert response.word_timestamps is False
+    assert response.internal_vad is False
 
 
 def test_cortex_error() -> None:
@@ -183,6 +191,7 @@ def test_cortex_payload() -> None:
         timestamps="s",
         use_batch=False,
         word_timestamps=False,
+        internal_vad=False,
         job_name="test_job",
         ping=False,
     )
@@ -197,6 +206,7 @@ def test_cortex_payload() -> None:
     assert payload.use_batch is False
     assert payload.vocab == []
     assert payload.word_timestamps is False
+    assert payload.internal_vad is False
     assert payload.job_name == "test_job"
     assert payload.ping is False
 
@@ -216,6 +226,7 @@ def test_cortex_url_response() -> None:
         use_batch=False,
         vocab=["custom company", "custom product"],
         word_timestamps=False,
+        internal_vad=False,
         dual_channel=False,
         job_name="test_job",
         request_id="test_request_id",
@@ -232,6 +243,7 @@ def test_cortex_url_response() -> None:
     assert response.use_batch is False
     assert response.vocab == ["custom company", "custom product"]
     assert response.word_timestamps is False
+    assert response.internal_vad is False
     assert response.dual_channel is False
     assert response.job_name == "test_job"
     assert response.request_id == "test_request_id"
@@ -252,6 +264,7 @@ def test_cortex_youtube_response() -> None:
         use_batch=False,
         vocab=["custom company", "custom product"],
         word_timestamps=False,
+        internal_vad=False,
         video_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         job_name="test_job",
         request_id="test_request_id",
@@ -268,6 +281,7 @@ def test_cortex_youtube_response() -> None:
     assert response.use_batch is False
     assert response.vocab == ["custom company", "custom product"]
     assert response.word_timestamps is False
+    assert response.internal_vad is False
     assert response.video_url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     assert response.job_name == "test_job"
     assert response.request_id == "test_request_id"
@@ -288,6 +302,7 @@ def test_youtube_response() -> None:
         use_batch=False,
         vocab=["custom company", "custom product"],
         word_timestamps=False,
+        internal_vad=False,
         video_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
     )
     assert response.utterances == [
@@ -302,4 +317,5 @@ def test_youtube_response() -> None:
     assert response.use_batch is False
     assert response.vocab == ["custom company", "custom product"]
     assert response.word_timestamps is False
+    assert response.internal_vad is False
     assert response.video_url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"

--- a/wordcab_transcribe/models.py
+++ b/wordcab_transcribe/models.py
@@ -111,6 +111,7 @@ class YouTubeResponse(BaseResponse):
                     "custom co-worker name",
                 ],
                 "word_timestamps": False,
+                "internal_vad": False,
                 "video_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
             }
         }
@@ -183,6 +184,7 @@ class CortexPayload(BaseModel):
                     "custom co-worker name",
                 ],
                 "word_timestamps": False,
+                "internal_vad": False,
                 "job_name": "job_abc123",
                 "ping": False,
             }

--- a/wordcab_transcribe/models.py
+++ b/wordcab_transcribe/models.py
@@ -30,6 +30,7 @@ class BaseResponse(BaseModel):
     use_batch: bool
     vocab: List[str]
     word_timestamps: bool
+    internal_vad: bool
 
 
 class AudioResponse(BaseResponse):
@@ -68,6 +69,7 @@ class AudioResponse(BaseResponse):
                     "custom co-worker name",
                 ],
                 "word_timestamps": False,
+                "internal_vad": False,
                 "dual_channel": False,
             }
         }
@@ -143,6 +145,7 @@ class CortexPayload(BaseModel):
     use_batch: Optional[bool] = False
     vocab: Optional[List[str]] = []
     word_timestamps: Optional[bool] = False
+    internal_vad: Optional[bool] = False
     job_name: Optional[str] = None
     ping: Optional[bool] = False
 
@@ -223,6 +226,7 @@ class CortexUrlResponse(AudioResponse):
                     "custom co-worker name",
                 ],
                 "word_timestamps": False,
+                "internal_vad": False,
                 "dual_channel": False,
                 "job_name": "job_name",
                 "request_id": "request_id",
@@ -231,7 +235,7 @@ class CortexUrlResponse(AudioResponse):
 
 
 class CortexYoutubeResponse(YouTubeResponse):
-    """Response model for the youtube type of the Cortex endpoint."""
+    """Response model for the YouTube type of the Cortex endpoint."""
 
     job_name: str
     request_id: Optional[str] = None
@@ -267,6 +271,7 @@ class CortexYoutubeResponse(YouTubeResponse):
                     "custom co-worker name",
                 ],
                 "word_timestamps": False,
+                "internal_vad": False,
                 "video_url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                 "job_name": "job_name",
                 "request_id": "request_id",
@@ -284,6 +289,7 @@ class BaseRequest(BaseModel):
     use_batch: bool = False
     vocab: List[str] = []
     word_timestamps: bool = False
+    internal_vad: bool = False
 
     @validator("timestamps")
     def validate_timestamps_values(cls, value: str) -> str:  # noqa: B902, N805
@@ -317,6 +323,7 @@ class BaseRequest(BaseModel):
                     "custom co-worker name",
                 ],
                 "word_timestamps": False,
+                "internal_vad": False,
             }
         }
 
@@ -343,6 +350,7 @@ class AudioRequest(BaseRequest):
                 ],
                 "word_timestamps": False,
                 "dual_channel": False,
+                "internal_vad": False,
             }
         }
 

--- a/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -47,6 +47,7 @@ async def inference_with_audio(  # noqa: C901
     use_batch: bool = Form(False),  # noqa: B008
     vocab: List[str] = Form([]),  # noqa: B008
     word_timestamps: bool = Form(False),  # noqa: B008
+    internal_vad: bool = Form(False),  # noqa: B008
     file: UploadFile = File(...),  # noqa: B008
 ) -> AudioResponse:
     """Inference endpoint with audio file."""
@@ -67,6 +68,7 @@ async def inference_with_audio(  # noqa: C901
         use_batch=use_batch,
         vocab=vocab,
         word_timestamps=word_timestamps,
+        internal_vad=internal_vad,
         dual_channel=dual_channel,
     )
 
@@ -100,6 +102,7 @@ async def inference_with_audio(  # noqa: C901
             use_batch=data.use_batch,
             vocab=data.vocab,
             word_timestamps=data.word_timestamps,
+            internal_vad=data.internal_vad,
         )
     )
     result = await task
@@ -125,4 +128,5 @@ async def inference_with_audio(  # noqa: C901
             use_batch=data.use_batch,
             vocab=data.vocab,
             word_timestamps=data.word_timestamps,
+            internal_vad=data.internal_vad,
         )

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -77,6 +77,7 @@ async def inference_with_audio_url(
             use_batch=data.use_batch,
             vocab=data.vocab,
             word_timestamps=data.word_timestamps,
+            internal_vad=data.internal_vad,
         )
     )
     result = await task
@@ -102,4 +103,5 @@ async def inference_with_audio_url(
             use_batch=data.use_batch,
             vocab=data.vocab,
             word_timestamps=data.word_timestamps,
+            internal_vad=data.internal_vad,
         )

--- a/wordcab_transcribe/router/v1/cortex_endpoint.py
+++ b/wordcab_transcribe/router/v1/cortex_endpoint.py
@@ -73,6 +73,7 @@ async def run_cortex(
                 use_batch=payload.use_batch,
                 vocab=payload.vocab,
                 word_timestamps=payload.word_timestamps,
+                internal_vad=payload.internal_vad,
             )
             response: AudioResponse = await inference_with_audio_url(
                 background_tasks=BackgroundTasks(),
@@ -89,6 +90,7 @@ async def run_cortex(
                 use_batch=payload.use_batch,
                 vocab=payload.vocab,
                 word_timestamps=payload.word_timestamps,
+                internal_vad=payload.internal_vad,
             )
             response: YouTubeResponse = await inference_with_youtube(
                 background_tasks=BackgroundTasks(),

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -79,5 +79,6 @@ async def inference_with_youtube(
             use_batch=data.use_batch,
             vocab=data.vocab,
             word_timestamps=data.word_timestamps,
+            internal_vad=data.internal_vad,
             video_url=url,
         )

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -54,6 +54,7 @@ async def inference_with_youtube(
             use_batch=data.use_batch,
             vocab=data.vocab,
             word_timestamps=data.word_timestamps,
+            internal_vad=data.internal_vad,
         )
     )
     result = await task

--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -119,6 +119,7 @@ class ASRAsyncService(ASRService):
         use_batch: bool,
         vocab: List[str],
         word_timestamps: bool,
+        internal_vad: bool,
     ) -> Union[Tuple[List[dict], float], Exception]:
         """Process the input request and return the results.
 
@@ -138,6 +139,7 @@ class ASRAsyncService(ASRService):
             use_batch (bool): Whether to use batch processing or not.
             vocab (List[str]): List of words to use for the vocabulary.
             word_timestamps (bool): Whether to return word timestamps or not.
+            internal_vad (bool): Whether to use faster-whisper's VAD or not.
 
         Returns:
             Union[Tuple[List[dict], float], Exception]: The final transcription result associated with the audio
@@ -168,6 +170,7 @@ class ASRAsyncService(ASRService):
             "use_batch": use_batch,
             "vocab": vocab,
             "word_timestamps": word_timestamps,
+            "internal_vad": internal_vad,
             "transcription_result": None,
             "transcription_done": asyncio.Event(),
             "diarization_result": None,
@@ -256,6 +259,7 @@ class ASRAsyncService(ASRService):
                 suppress_blank=False,
                 vocab=None if task["vocab"] == [] else task["vocab"],
                 word_timestamps=True,
+                internal_vad=task["internal_vad"],
                 vad_service=self.services["vad"] if task["dual_channel"] else None,
                 use_batch=task["use_batch"],
             )

--- a/wordcab_transcribe/services/transcribe_service.py
+++ b/wordcab_transcribe/services/transcribe_service.py
@@ -871,7 +871,7 @@ class TranscribeService:
                 initial_prompt=prompt,
                 suppress_blank=False,
                 word_timestamps=True,
-                vad_filter=internal_vad,
+                vad_filter=False,
             )
             segments = list(segments)
 

--- a/wordcab_transcribe/services/transcribe_service.py
+++ b/wordcab_transcribe/services/transcribe_service.py
@@ -343,6 +343,7 @@ class TranscribeService:
         suppress_blank: bool = False,
         vocab: Optional[List[str]] = None,
         word_timestamps: bool = True,
+        internal_vad: bool = False,
         vad_service: Optional[VadService] = None,
         use_batch: bool = True,
     ) -> Union[List[dict], List[List[dict]]]:
@@ -358,6 +359,7 @@ class TranscribeService:
             suppress_blank (bool): Whether to suppress blank at the beginning of the sampling.
             vocab (Optional[List[str]]): Vocabulary to use during generation if not None.
             word_timestamps (bool): Whether to return word timestamps.
+            internal_vad (bool): Whether to use faster-whisper's VAD or not.
             vad_service (Optional[VADService]): VADService to use for voice activity detection in the dual_channel case.
             use_batch (bool): Whether to use batch inference.
 
@@ -411,6 +413,7 @@ class TranscribeService:
                 initial_prompt=prompt,
                 suppress_blank=False,
                 word_timestamps=True,
+                vad_filter=internal_vad,
             )
             # segments, _ = self.models[model_index].model.transcribe(
             #     audio,
@@ -431,6 +434,7 @@ class TranscribeService:
                         source_lang=source_lang,
                         speaker_id=audio_index,
                         vad_service=vad_service,
+                        internal_vad=internal_vad,
                         prompt=prompt,
                     )
                 )
@@ -831,6 +835,7 @@ class TranscribeService:
         source_lang: str,
         speaker_id: int,
         vad_service: VadService,
+        internal_vad: bool,
         prompt: Optional[str] = None,
     ) -> List[dict]:
         """
@@ -841,6 +846,7 @@ class TranscribeService:
             source_lang (str): Language of the audio file.
             speaker_id (int): Speaker ID used in the diarization.
             vad_service (VadService): VAD service.
+            internal_vad (bool): Whether to use faster-whisper's VAD or not.
             prompt (Optional[str]): Initial prompt to use for the generation.
 
         Returns:
@@ -865,6 +871,7 @@ class TranscribeService:
                 initial_prompt=prompt,
                 suppress_blank=False,
                 word_timestamps=True,
+                vad_filter=internal_vad,
             )
             segments = list(segments)
 


### PR DESCRIPTION
Adding `internal_vad` parameter which seems to fix output with empty utterances