### PR TITLE
adding internal_vad=True as a default fallback in case segments are empty

### DIFF
--- a/wordcab_transcribe/services/transcribe_service.py
+++ b/wordcab_transcribe/services/transcribe_service.py
@@ -423,6 +423,17 @@ class TranscribeService:
             #     word_timestamps=True,
             # )
 
+            segments = list(segments)
+            if not segments and not internal_vad:
+                segments, _ = self.model.transcribe(
+                    audio,
+                    language=source_lang,
+                    initial_prompt=prompt,
+                    suppress_blank=False,
+                    word_timestamps=True,
+                    vad_filter=True,
+                )
+
             outputs = [segment._asdict() for segment in segments]
 
         else:


### PR DESCRIPTION
adding `internal_vad=True` as a default fallback in case segments are empty