### PR TITLE
Add a download queue

### DIFF
--- a/wordcab_transcribe/dependencies.py
+++ b/wordcab_transcribe/dependencies.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 """Dependencies for the API."""
 
-import multiprocessing
-from concurrent.futures import ThreadPoolExecutor
-
 from wordcab_transcribe.config import settings
 from wordcab_transcribe.services.asr_service import ASRAsyncService, ASRLiveService
 
@@ -27,11 +24,3 @@ elif settings.asr_type == "async":
     asr = ASRAsyncService()
 else:
     raise ValueError(f"Invalid ASR type: {settings.asr_type}")
-
-
-hardware_num_cores = multiprocessing.cpu_count()
-
-# Define the number of workers for the I/O bound tasks
-io_executor = ThreadPoolExecutor(max_workers=hardware_num_cores)
-
-# TODO: Define the number of workers for the CPU bound tasks: Transcription, Alignment, Diarization

--- a/wordcab_transcribe/dependencies.py
+++ b/wordcab_transcribe/dependencies.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Dependencies for the API."""
 
+import asyncio
+
 from wordcab_transcribe.config import settings
 from wordcab_transcribe.services.asr_service import ASRAsyncService, ASRLiveService
 
@@ -24,3 +26,7 @@ elif settings.asr_type == "async":
     asr = ASRAsyncService()
 else:
     raise ValueError(f"Invalid ASR type: {settings.asr_type}")
+
+
+# Define the maximum number of files to pre-download for the async ASR service
+download_limit = asyncio.Semaphore(10)

--- a/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -45,7 +45,7 @@ async def inference_with_audio_url(
 
     data = AudioRequest() if data is None else AudioRequest(**data.dict())
 
-    _filepath = await download_audio_file(url, filename)
+    _filepath = await download_audio_file("url", url, filename)
 
     if data.dual_channel:
         try:

--- a/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -21,9 +21,9 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException
 from fastapi import status as http_status
 from loguru import logger
 
-from wordcab_transcribe.dependencies import asr, io_executor
+from wordcab_transcribe.dependencies import asr
 from wordcab_transcribe.models import BaseRequest, YouTubeResponse
-from wordcab_transcribe.utils import delete_file, download_file_from_youtube
+from wordcab_transcribe.utils import delete_file, download_audio_file
 
 
 router = APIRouter()
@@ -37,9 +37,7 @@ async def inference_with_youtube(
 ) -> YouTubeResponse:
     """Inference endpoint with YouTube url."""
     filename = f"yt_{shortuuid.ShortUUID().random(length=32)}"
-    filepath = await asyncio.get_running_loop().run_in_executor(
-        io_executor, download_file_from_youtube, url, filename
-    )
+    filepath = await download_audio_file("youtube", url, filename)
 
     data = BaseRequest() if data is None else BaseRequest(**data.dict())
 

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -59,9 +59,6 @@ CURRENCIES_CHARACTERS = [
     "₿",
 ]
 
-# Define the maximum number of files to pre-download for the async ASR service
-download_limit = asyncio.Semaphore(10)
-
 
 # pragma: no cover
 async def async_run_subprocess(command: List[str]) -> tuple:
@@ -274,15 +271,14 @@ async def download_audio_file(
     Returns:
         Union[str, Awaitable[str]]: Path to the downloaded file.
     """
-    async with download_limit:
-        if source == "youtube":
-            filename = await asyncio.get_running_loop().run_in_executor(
-                None, _download_file_from_youtube, url, filename
-            )
-        elif source == "url":
-            filename = await _download_file_from_url(url, filename, url_headers)
-        else:
-            raise ValueError(f"Invalid source: {source}. Valid sources are: youtube, url.")
+    if source == "youtube":
+        filename = await asyncio.get_running_loop().run_in_executor(
+            None, _download_file_from_youtube, url, filename
+        )
+    elif source == "url":
+        filename = await _download_file_from_url(url, filename, url_headers)
+    else:
+        raise ValueError(f"Invalid source: {source}. Valid sources are: youtube, url.")
     
     return filename
 

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -279,7 +279,7 @@ async def download_audio_file(
         filename = await _download_file_from_url(url, filename, url_headers)
     else:
         raise ValueError(f"Invalid source: {source}. Valid sources are: youtube, url.")
-    
+
     return filename
 
 


### PR DESCRIPTION
This PR update the code to include a download queue for audio files.

Only 10 files can be downloaded at the same time. Youtube and audio-url endpoints share this hard limit by using the `asyncio.Semaphore` tool.