### PR TITLE
Setting prompt="" instead of None, as None causes empty output for some presigned URLs

### DIFF
--- a/wordcab_transcribe/services/transcribe_service.py
+++ b/wordcab_transcribe/services/transcribe_service.py
@@ -402,7 +402,7 @@ class TranscribeService:
             words = ", ".join(vocab)
             prompt = f"Vocab: {words[:-2]}"
         else:
-            prompt = None
+            prompt = ""
 
         if not isinstance(audio, tuple):
             if isinstance(audio, torch.Tensor):


### PR DESCRIPTION
Setting prompt="" instead of None, as None causes empty output for some presigned URLs