### PR TITLE
Add concurrency on CI tests

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,9 +1,18 @@
 name: Quality Checks
 
 on:
-  pull_request:
+  push:
     branches:
       - main
+  pull_request:
+      paths:
+      - 'wordcab_transcribe/**'
+      - 'tests/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   quality:


### PR DESCRIPTION
This PR adds concurrency to auto-remove concurrent CI tests. It also runs tests only when files under `wordcab_transcribe` and `tests` folders are modified.