### PR TITLE
Add empty audio catch

### DIFF
--- a/wordcab_transcribe/services/asr_service.py
+++ b/wordcab_transcribe/services/asr_service.py
@@ -303,7 +303,7 @@ class ASRAsyncService(ASRService):
             self.gpu_handler.release_device(gpu_index)
             return task["diarization_result"]
 
-        if task["diarization_result"] is None:
+        if diarization and task["diarization_result"] is None:
             # Empty audio early return
             return early_return(duration=duration)
 

--- a/wordcab_transcribe/services/diarization/diarize_service.py
+++ b/wordcab_transcribe/services/diarization/diarize_service.py
@@ -119,6 +119,9 @@ class DiarizeService:
         """
         vad_outputs, _ = vad_service(waveform, group_timestamps=False)
 
+        if len(vad_outputs) == 0:  # Empty audio
+            return None
+
         if audio_duration < 3600:
             scale_dict = self.default_scale_dict
             segmentation_batch_size = self.default_segmentation_batch_size

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -410,7 +410,7 @@ def early_return(duration: float) -> Tuple[List[dict], dict, float]:
     return (
         [
             {
-                "text": "Empty audio",
+                "text": "<EMPTY AUDIO>",
                 "start": 0,
                 "end": duration,
                 "speaker": None,

--- a/wordcab_transcribe/utils.py
+++ b/wordcab_transcribe/utils.py
@@ -396,6 +396,38 @@ def delete_file(filepath: Union[str, Tuple[str, Optional[str]]]) -> None:
             Path(path).unlink(missing_ok=True)
 
 
+def early_return(duration: float) -> Tuple[List[dict], dict, float]:
+    """
+    Early return for empty audio files.
+
+    Args:
+        duration (float): Duration of the audio file.
+
+    Returns:
+        Tuple[List[dict], dict, float]:
+            Empty segments, process times and audio duration.
+    """
+    return (
+        [
+            {
+                "text": "Empty audio",
+                "start": 0,
+                "end": duration,
+                "speaker": None,
+                "words": None,
+            }
+        ],
+        {
+            "total": 0,
+            "transcription": 0,
+            "alignment": None,
+            "diarization": None,
+            "post_processing": 0,
+        },
+        duration,
+    )
+
+
 def enhance_audio(
     audio: Union[str, torch.Tensor],
     apply_agc: Optional[bool] = True,


### PR DESCRIPTION
Here is an example of an empty audio returned to a request:

```json
{
    "utterances": [
        {
            "text": "Empty audio",
            "start": 0.0,
            "end": 27.52,
            "speaker": null,
            "words": null
        }
    ],
    "audio_duration": 27.52,
    "alignment": false,
    "num_speakers": -1,
    "diarization": false,
    "source_lang": "en",
    "timestamps": "s",
    "vocab": [],
    "word_timestamps": false,
    "internal_vad": false,
    "repetition_penalty": 1.2,
    "compression_ratio_threshold": 2.4,
    "log_prob_threshold": -1.0,
    "no_speech_threshold": 0.6,
    "condition_on_previous_text": true,
    "process_times": {
        "total": 0.0,
        "transcription": 0.0,
        "diarization": null,
        "alignment": null,
        "post_processing": 0.0
    },
    "dual_channel": false
}
```