### PR TITLE
Add offset audio transcription

### DIFF
--- a/notebooks/local_audio_inference.py
+++ b/notebooks/local_audio_inference.py
@@ -8,12 +8,14 @@ filepath = "data/HL_Podcast_1.mp3"
 # filepath = "data/1693323170.139915.139915&delay=10.mp3"
 
 data = {
-    "num_speakers": 2,  # Leave at -1 to guess the number of speakers
+    "offset_start": 23,
+    "offset_end": 186.5,
+    "num_speakers": -1,  # Leave at -1 to guess the number of speakers
     "diarization": True,  # Longer processing time but speaker segment attribution
     "dual_channel": False,  # Only for stereo audio files with one speaker per channel
     "source_lang": "en",  # optional, default is "en"
     "timestamps": "s",  # optional, default is "s". Can be "s", "ms" or "hms".
-    "word_timestamps": True,  # optional, default is False
+    "word_timestamps": False,  # optional, default is False
     "internal_vad": False,
 }
 

--- a/notebooks/youtube_inference.py
+++ b/notebooks/youtube_inference.py
@@ -14,6 +14,8 @@ params = {"url": "https://youtu.be/ry9SYnV3svc"}  # eng sample - 2 speakers
 # params = {"url": "https://youtu.be/JJbtS8CMr80"}  # 4h - multiple speakers
 
 data = {
+    "offset_start": None,
+    "offset_end": None,
     "num_speakers": -1,  # Leave at -1 to guess the number of speakers
     "diarization": True,  # Longer processing time but speaker segment attribution
     "source_lang": "en",  # optional, default is "en"

--- a/src/wordcab_transcribe/models.py
+++ b/src/wordcab_transcribe/models.py
@@ -55,8 +55,8 @@ class Utterance(BaseModel):
     """Utterance model for the API."""
 
     text: str
-    start: float
-    end: float
+    start: Union[float, str]
+    end: Union[float, str]
     speaker: Optional[int]
     words: Optional[List[Word]]
 
@@ -66,6 +66,8 @@ class BaseResponse(BaseModel):
 
     utterances: List[Utterance]
     audio_duration: float
+    offset_start: Union[float, None]
+    offset_end: Union[float, None]
     num_speakers: int
     diarization: bool
     source_lang: str
@@ -106,6 +108,8 @@ class AudioResponse(BaseResponse):
                     },
                 ],
                 "audio_duration": 2.678,
+                "offset_start": None,
+                "offset_end": None,
                 "num_speakers": -1,
                 "diarization": False,
                 "source_lang": "en",
@@ -158,6 +162,8 @@ class YouTubeResponse(BaseResponse):
                     },
                 ],
                 "audio_duration": 2.0,
+                "offset_start": None,
+                "offset_end": None,
                 "num_speakers": -1,
                 "diarization": False,
                 "source_lang": "en",
@@ -206,6 +212,8 @@ class CortexPayload(BaseModel):
     url_type: Literal["audio_url", "youtube"]
     url: Optional[str] = None
     api_key: Optional[str] = None
+    offset_start: Optional[float] = None
+    offset_end: Optional[float] = None
     num_speakers: Optional[int] = -1
     diarization: Optional[bool] = False
     dual_channel: Optional[bool] = False
@@ -230,6 +238,8 @@ class CortexPayload(BaseModel):
                 "url_type": "youtube",
                 "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
                 "api_key": "1234567890",
+                "offset_start": None,
+                "offset_end": None,
                 "num_speakers": -1,
                 "diarization": False,
                 "dual_channel": False,
@@ -279,6 +289,8 @@ class CortexUrlResponse(AudioResponse):
                     },
                 ],
                 "audio_duration": 2.0,
+                "offset_start": None,
+                "offset_end": None,
                 "num_speakers": -1,
                 "diarization": False,
                 "source_lang": "en",
@@ -334,6 +346,8 @@ class CortexYoutubeResponse(YouTubeResponse):
                     },
                 ],
                 "audio_duration": 2.0,
+                "offset_start": None,
+                "offset_end": None,
                 "num_speakers": -1,
                 "diarization": False,
                 "source_lang": "en",
@@ -366,6 +380,8 @@ class CortexYoutubeResponse(YouTubeResponse):
 class BaseRequest(BaseModel):
     """Base request model for the API."""
 
+    offset_start: Union[float, None] = None
+    offset_end: Union[float, None] = None
     num_speakers: int = -1
     diarization: bool = False
     source_lang: str = "en"
@@ -394,6 +410,8 @@ class BaseRequest(BaseModel):
 
         json_schema_extra = {
             "example": {
+                "offset_start": None,
+                "offset_end": None,
                 "num_speakers": -1,
                 "diarization": False,
                 "source_lang": "en",
@@ -424,6 +442,8 @@ class AudioRequest(BaseRequest):
 
         json_schema_extra = {
             "example": {
+                "offset_start": None,
+                "offset_end": None,
                 "num_speakers": -1,
                 "diarization": False,
                 "source_lang": "en",

--- a/src/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/src/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -44,6 +44,8 @@ router = APIRouter()
 )
 async def inference_with_audio(  # noqa: C901
     background_tasks: BackgroundTasks,
+    offset_start: float = Form(None),  # noqa: B008
+    offset_end: float = Form(None),  # noqa: B008
     num_speakers: int = Form(-1),  # noqa: B008
     diarization: bool = Form(False),  # noqa: B008
     dual_channel: bool = Form(False),  # noqa: B008
@@ -70,6 +72,8 @@ async def inference_with_audio(  # noqa: C901
     await save_file_locally(filename=filename, file=file)
 
     data = AudioRequest(
+        offset_start=offset_start,
+        offset_end=offset_end,
         num_speakers=num_speakers,
         diarization=diarization,
         source_lang=source_lang,
@@ -107,6 +111,8 @@ async def inference_with_audio(  # noqa: C901
     task = asyncio.create_task(
         asr.process_input(
             filepath=filepath,
+            offset_start=data.offset_start,
+            offset_end=data.offset_end,
             num_speakers=data.num_speakers,
             diarization=data.diarization,
             dual_channel=data.dual_channel,
@@ -137,6 +143,8 @@ async def inference_with_audio(  # noqa: C901
         return AudioResponse(
             utterances=utterances,
             audio_duration=audio_duration,
+            offset_start=data.offset_start,
+            offset_end=data.offset_end,
             num_speakers=data.num_speakers,
             diarization=data.diarization,
             dual_channel=data.dual_channel,

--- a/src/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/src/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -75,6 +75,8 @@ async def inference_with_audio_url(
         task = asyncio.create_task(
             asr.process_input(
                 filepath=filepath,
+                offset_start=data.offset_start,
+                offset_end=data.offset_end,
                 num_speakers=data.num_speakers,
                 diarization=data.diarization,
                 dual_channel=data.dual_channel,
@@ -105,6 +107,8 @@ async def inference_with_audio_url(
         return AudioResponse(
             utterances=utterances,
             audio_duration=audio_duration,
+            offset_start=data.offset_start,
+            offset_end=data.offset_end,
             num_speakers=data.num_speakers,
             diarization=data.diarization,
             dual_channel=data.dual_channel,

--- a/src/wordcab_transcribe/router/v1/cortex_endpoint.py
+++ b/src/wordcab_transcribe/router/v1/cortex_endpoint.py
@@ -69,6 +69,8 @@ async def run_cortex(
     try:
         if payload.url_type == "audio_url":
             data = AudioRequest(
+                offset_start=payload.offset_start,
+                offset_end=payload.offset_end,
                 num_speakers=payload.num_speakers,
                 diarization=payload.diarization,
                 dual_channel=payload.dual_channel,
@@ -91,6 +93,8 @@ async def run_cortex(
 
         elif payload.url_type == "youtube":
             data = BaseRequest(
+                offset_start=payload.offset_start,
+                offset_end=payload.offset_end,
                 num_speakers=payload.num_speakers,
                 diarization=payload.diarization,
                 source_lang=payload.source_lang,
@@ -133,7 +137,7 @@ async def run_cortex(
         return CortexError(message=error_message)
 
     _cortex_response = {
-        **response.dict(),
+        **response.model_dump(),
         "job_name": payload.job_name,
         "request_id": request_id,
     }

--- a/src/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/src/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -46,11 +46,13 @@ async def inference_with_youtube(
     async with download_limit:
         filepath = await download_audio_file("youtube", url, filename)
 
-        data = BaseRequest() if data is None else BaseRequest(**data.dict())
+        data = BaseRequest() if data is None else BaseRequest(**data.model_dump())
 
         task = asyncio.create_task(
             asr.process_input(
                 filepath=filepath,
+                offset_start=data.offset_start,
+                offset_end=data.offset_end,
                 num_speakers=data.num_speakers,
                 diarization=data.diarization,
                 dual_channel=False,
@@ -81,6 +83,8 @@ async def inference_with_youtube(
         return YouTubeResponse(
             utterances=utterances,
             audio_duration=audio_duration,
+            offset_start=data.offset_start,
+            offset_end=data.offset_end,
             num_speakers=data.num_speakers,
             diarization=data.diarization,
             source_lang=data.source_lang,

--- a/src/wordcab_transcribe/services/post_processing_service.py
+++ b/src/wordcab_transcribe/services/post_processing_service.py
@@ -19,7 +19,7 @@
 # and limitations under the License.
 """Post-Processing Service for audio files."""
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from wordcab_transcribe.utils import convert_timestamp, format_punct, is_empty_string
 
@@ -341,6 +341,7 @@ class PostProcessingService:
         utterances: List[dict],
         diarization: bool,
         dual_channel: bool,
+        offset_start: Union[float, None],
         timestamps_format: str,
         word_timestamps: bool,
     ) -> List[dict]:
@@ -351,18 +352,29 @@ class PostProcessingService:
             utterances (List[dict]): List of utterances.
             diarization (bool): Whether diarization is enabled.
             dual_channel (bool): Whether dual channel is enabled.
+            offset_start (Union[float, None]): Offset start.
             timestamps_format (str): Timestamps format used for conversion.
             word_timestamps (bool): Whether to include word timestamps.
 
         Returns:
             List[dict]: List of utterances with final processing.
         """
+        if offset_start is not None:
+            offset_start = float(offset_start)
+        else:
+            offset_start = 0.0
+
         include_speaker = diarization or dual_channel
+
         _utterances = [
             {
                 "text": format_punct(utterance["text"]),
-                "start": convert_timestamp(utterance["start"], timestamps_format),
-                "end": convert_timestamp(utterance["end"], timestamps_format),
+                "start": convert_timestamp(
+                    (utterance["start"] + offset_start), timestamps_format
+                ),
+                "end": convert_timestamp(
+                    (utterance["end"] + offset_start), timestamps_format
+                ),
                 "speaker": int(utterance["speaker"]) if include_speaker else None,
                 "words": utterance["words"] if word_timestamps else [],
             }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -150,6 +150,8 @@ def test_audio_request() -> None:
         source_lang="en",
         timestamps="s",
     )
+    assert request.offset_start is None
+    assert request.offset_end is None
     assert request.num_speakers == -1
     assert request.diarization is True
     assert request.dual_channel is True
@@ -170,6 +172,8 @@ def test_audio_response() -> None:
     response = AudioResponse(
         utterances=[],
         audio_duration=0.0,
+        offset_start=None,
+        offset_end=None,
         num_speakers=-1,
         diarization=False,
         dual_channel=False,
@@ -192,6 +196,8 @@ def test_audio_response() -> None:
     )
     assert response.utterances == []
     assert response.audio_duration == 0.0
+    assert response.offset_start is None
+    assert response.offset_end is None
     assert response.num_speakers == -1
     assert response.diarization is False
     assert response.dual_channel is False
@@ -230,6 +236,8 @@ def test_audio_response() -> None:
             ),
         ],
         audio_duration=6.0,
+        offset_start=None,
+        offset_end=None,
         num_speakers=-1,
         diarization=True,
         dual_channel=True,
@@ -267,6 +275,8 @@ def test_audio_response() -> None:
         ),
     ]
     assert response.audio_duration == 6.0
+    assert response.offset_start is None
+    assert response.offset_end is None
     assert response.num_speakers == -1
     assert response.diarization is True
     assert response.dual_channel is True
@@ -302,6 +312,8 @@ def test_base_request_valid() -> None:
 def test_base_request_default() -> None:
     """Test the BaseRequest model with default values."""
     req = BaseRequest()
+    assert req.offset_start is None
+    assert req.offset_end is None
     assert req.num_speakers == -1
     assert req.diarization is False
     assert req.source_lang == "en"
@@ -341,6 +353,8 @@ def test_base_response() -> None:
             ),
         ],
         audio_duration=6.0,
+        offset_start=None,
+        offset_end=None,
         num_speakers=-1,
         diarization=False,
         source_lang="en",
@@ -377,6 +391,8 @@ def test_base_response() -> None:
         ),
     ]
     assert response.audio_duration == 6.0
+    assert response.offset_start is None
+    assert response.offset_end is None
     assert response.num_speakers == -1
     assert response.diarization is False
     assert response.source_lang == "en"
@@ -411,6 +427,8 @@ def test_cortex_payload() -> None:
         url_type="youtube",
         url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         api_key="test_api_key",
+        offset_start=None,
+        offset_end=None,
         num_speakers=-1,
         diarization=False,
         dual_channel=False,
@@ -425,6 +443,8 @@ def test_cortex_payload() -> None:
     assert payload.url_type == "youtube"
     assert payload.url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     assert payload.api_key == "test_api_key"
+    assert payload.offset_start is None
+    assert payload.offset_end is None
     assert payload.num_speakers == -1
     assert payload.diarization is False
     assert payload.dual_channel is False
@@ -462,6 +482,8 @@ def test_cortex_url_response() -> None:
             ),
         ],
         audio_duration=6.0,
+        offset_start=None,
+        offset_end=None,
         num_speakers=-1,
         diarization=False,
         source_lang="en",
@@ -501,6 +523,8 @@ def test_cortex_url_response() -> None:
         ),
     ]
     assert response.audio_duration == 6.0
+    assert response.offset_start is None
+    assert response.offset_end is None
     assert response.num_speakers == -1
     assert response.diarization is False
     assert response.source_lang == "en"
@@ -544,6 +568,8 @@ def test_cortex_youtube_response() -> None:
             ),
         ],
         audio_duration=6.0,
+        offset_start=None,
+        offset_end=None,
         num_speakers=-1,
         diarization=False,
         source_lang="en",
@@ -583,6 +609,8 @@ def test_cortex_youtube_response() -> None:
         ),
     ]
     assert response.audio_duration == 6.0
+    assert response.offset_start is None
+    assert response.offset_end is None
     assert response.num_speakers == -1
     assert response.diarization is False
     assert response.source_lang == "en"
@@ -626,6 +654,8 @@ def test_youtube_response() -> None:
             ),
         ],
         audio_duration=6.0,
+        offset_start=None,
+        offset_end=None,
         num_speakers=-1,
         diarization=False,
         source_lang="en",
@@ -663,6 +693,8 @@ def test_youtube_response() -> None:
         ),
     ]
     assert response.audio_duration == 6.0
+    assert response.offset_start is None
+    assert response.offset_end is None
     assert response.num_speakers == -1
     assert response.diarization is False
     assert response.source_lang == "en"

--- a/tests/utils/test_convert_functions.py
+++ b/tests/utils/test_convert_functions.py
@@ -23,8 +23,6 @@ from typing import Union
 import pytest
 
 from wordcab_transcribe.utils import (
-    _convert_ms_to_hms,
-    _convert_ms_to_s,
     _convert_s_to_hms,
     _convert_s_to_ms,
     convert_timestamp,
@@ -52,21 +50,6 @@ def test_convert_timestamp_raises_error() -> None:
     """Test the convert_timestamp function raises error."""
     with pytest.raises(ValueError):
         convert_timestamp(1000, "invalid_target", False)
-
-
-@pytest.mark.parametrize("ms, expected", [(1000, 1), (3600000, 3600), (3661000, 3661)])
-def test_convert_ms_to_s(ms: float, expected: float) -> None:
-    """Test the _convert_ms_to_s function."""
-    assert _convert_ms_to_s(ms) == expected
-
-
-@pytest.mark.parametrize(
-    "ms, expected",
-    [(1000, "00:00:01.000"), (3600000, "01:00:00.000"), (3661000, "01:01:01.000")],
-)
-def test_convert_ms_to_hms(ms: float, expected: str) -> None:
-    """Test the _convert_ms_to_hms function."""
-    assert _convert_ms_to_hms(ms) == expected
 
 
 @pytest.mark.parametrize("s, expected", [(1, 1000), (3600, 3600000), (3661, 3661000)])


### PR DESCRIPTION
This PR:
* Added `offset_start` and `offset_end` parameters to choose when to start and end the transcription
* Added the `offset_start` to post-processing step
* Removed unused conversion functions (old `ms` to format functions)
* Fixed the `hms` formatting, which was not displaying milliseconds correctly
* Fixed the `Utterance` model to handle strings for `start` and `end` keys (`hms` requirement)