### PR TITLE
Add auto dual-channel detection

### DIFF
--- a/src/wordcab_transcribe/router/v1/audio_file_endpoint.py
+++ b/src/wordcab_transcribe/router/v1/audio_file_endpoint.py
@@ -30,6 +30,7 @@ from loguru import logger
 from wordcab_transcribe.dependencies import asr
 from wordcab_transcribe.models import AudioRequest, AudioResponse
 from wordcab_transcribe.utils import (
+    check_num_channels,
     convert_file_to_wav,
     delete_file,
     save_file_locally,
@@ -89,9 +90,12 @@ async def inference_with_audio(  # noqa: C901
         dual_channel=dual_channel,
     )
 
-    if data.dual_channel:
+    num_channels = await check_num_channels(filename)
+
+    if data.dual_channel or num_channels == 2:
         try:
             filepath = await split_dual_channel_file(filename)
+            data.dual_channel = True
         except Exception as e:
             logger.error(f"{e}\nFallback to single channel mode.")
             data.dual_channel = False

--- a/src/wordcab_transcribe/router/v1/audio_url_endpoint.py
+++ b/src/wordcab_transcribe/router/v1/audio_url_endpoint.py
@@ -30,6 +30,7 @@ from loguru import logger
 from wordcab_transcribe.dependencies import asr, download_limit
 from wordcab_transcribe.models import AudioRequest, AudioResponse
 from wordcab_transcribe.utils import (
+    check_num_channels,
     convert_file_to_wav,
     delete_file,
     download_audio_file,
@@ -53,9 +54,12 @@ async def inference_with_audio_url(
     async with download_limit:
         _filepath = await download_audio_file("url", url, filename)
 
-        if data.dual_channel:
+        num_channels = await check_num_channels(_filepath)
+
+        if data.dual_channel or num_channels == 2:
             try:
                 filepath = await split_dual_channel_file(_filepath)
+                data.dual_channel = True
             except Exception as e:
                 logger.error(f"{e}\nFallback to single channel mode.")
                 data.dual_channel = False

--- a/src/wordcab_transcribe/services/asr_service.py
+++ b/src/wordcab_transcribe/services/asr_service.py
@@ -315,7 +315,11 @@ class ASRAsyncService(ASRService):
                 gpu_index = -1
                 return task["diarization_result"]
 
-            if diarization and task["diarization_result"] is None:
+            if (
+                diarization
+                and task["diarization_result"] is None
+                and dual_channel is False
+            ):
                 # Empty audio early return
                 return early_return(duration=duration)
 


### PR DESCRIPTION
This PR:
* Added a parameter to `youtube-dl` to make it `quiet`
* Adds `dual_channel` auto-detection for audio URL and audio file endpoint (not youtube)
* Fix a bug that returned `<EMPTY AUDIO>` when `dual_channel` was enabled with `diarization`