### PR TITLE
Replace `dual_channel` by `multi_channel` process

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ filepath = "/path/to/audio/file.wav"  # or any other convertible format by ffmpe
 data = {
   "num_speakers": -1,  # # Leave at -1 to guess the number of speakers
   "diarization": True,  # Longer processing time but speaker segment attribution
-  "dual_channel": False,  # Only for stereo audio files with one speaker per channel
+  "multi_channel": False,  # Only for stereo audio files with one speaker per channel
   "source_lang": "en",  # optional, default is "en"
   "timestamps": "s",  # optional, default is "s". Can be "s", "ms" or "hms".
   "word_timestamps": False,  # optional, default is False

--- a/notebooks/local_audio_inference.py
+++ b/notebooks/local_audio_inference.py
@@ -4,16 +4,17 @@ import requests
 
 # filepath = "data/short_one_speaker.mp3"
 # filepath = "data/24118946.mp3"
-filepath = "data/HL_Podcast_1.mp3"
+# filepath = "data/HL_Podcast_1.mp3"
 # filepath = "data/1693323170.139915.139915&delay=10.mp3"
+filepath = "data/2414612_1692939445.333949_2023_08_25_045726_0.mp3"
 
 data = {
-    "offset_start": 23,
-    "offset_end": 186.5,
+    "offset_start": None,
+    "offset_end": None,
     "num_speakers": -1,  # Leave at -1 to guess the number of speakers
     "diarization": True,  # Longer processing time but speaker segment attribution
-    "dual_channel": False,  # Only for stereo audio files with one speaker per channel
-    "source_lang": "en",  # optional, default is "en"
+    "multi_channel": True,  # Only for stereo audio files with one speaker per channel
+    "source_lang": "th",  # optional, default is "en"
     "timestamps": "s",  # optional, default is "s". Can be "s", "ms" or "hms".
     "word_timestamps": False,  # optional, default is False
     "internal_vad": False,

--- a/src/wordcab_transcribe/automate.py
+++ b/src/wordcab_transcribe/automate.py
@@ -94,7 +94,7 @@ def run_audio_url(
     timestamps: str = "s",
     word_timestamps: bool = False,
     diarization: bool = False,
-    dual_channel: bool = False,
+    multi_channel: bool = False,
     server_url: Optional[str] = None,
     vocab: Optional[List[str]] = None,
     timeout: int = 900,
@@ -108,7 +108,7 @@ def run_audio_url(
         timestamps: time unit of the timestamps (defaulted to seconds)
         word_timestamps: associated words and their timestamps (defaulted to False)
         diarization: speaker labels for utterances (defaulted to False)
-        dual_channel: defaulted to False
+        multi_channel: defaulted to False
         server_url: the URL used to reach out the API
         vocab: defaulted to empty list
         timeout: defaulted to 90 seconds (15 minutes)
@@ -125,7 +125,7 @@ def run_audio_url(
         "source_lang": source_lang,
         "timestamps": timestamps,
         "word_timestamps": word_timestamps,
-        "dual_channel": dual_channel,
+        "multi_channel": multi_channel,
     }
     if vocab:
         data["vocab"] = vocab
@@ -163,7 +163,7 @@ def run_api_audio_file(
     timestamps: str = "s",
     word_timestamps: bool = False,
     diarization: bool = False,
-    dual_channel: bool = False,
+    multi_channel: bool = False,
     server_url: Optional[str] = None,
     vocab: Optional[List[str]] = None,
     timeout: int = 900,
@@ -177,7 +177,7 @@ def run_api_audio_file(
         timestamps: time unit of the timestamps (defaulted to seconds)
         word_timestamps: associated words and their timestamps (defaulted to False)
         diarization: speaker labels for utterances (defaulted to False)
-        dual_channel: defaulted to False
+        multi_channel: defaulted to False
         server_url: the URL used to reach out the API
         vocab: defaulted to empty list
         timeout: defaulted to 90 seconds (15 minutes)
@@ -190,7 +190,7 @@ def run_api_audio_file(
         "source_lang": source_lang,
         "timestamps": timestamps,
         "word_timestamps": word_timestamps,
-        "dual_channel": dual_channel,
+        "multi_channel": multi_channel,
     }
     if vocab:
         data["vocab"] = vocab
@@ -230,7 +230,7 @@ def run_api(
     timestamps: str = "s",
     word_timestamps: bool = False,
     diarization: bool = False,
-    dual_channel: bool = False,
+    multi_channel: bool = False,
     server_url: Optional[str] = None,
     vocab: Optional[List[str]] = None,
     timeout: int = 900,
@@ -245,7 +245,7 @@ def run_api(
         timestamps: time unit of the timestamps (defaulted to seconds)
         word_timestamps: whether the timestamps are represented by words (defaulted to False)
         diarization: speaker labels for utterances (defaulted to False)
-        dual_channel: defaulted to False
+        multi_channel: defaulted to False
         server_url: the URL used to reach out the API
         vocab: defaulted to empty list
         timeout: defaulted to 900 seconds (15 minutes)
@@ -271,7 +271,7 @@ def run_api(
             timestamps,
             word_timestamps,
             diarization,
-            dual_channel,
+            multi_channel,
             server_url,
             vocab,
             timeout,
@@ -283,7 +283,7 @@ def run_api(
             timestamps,
             word_timestamps,
             diarization,
-            dual_channel,
+            multi_channel,
             server_url,
             vocab,
             timeout,

--- a/src/wordcab_transcribe/models.py
+++ b/src/wordcab_transcribe/models.py
@@ -86,7 +86,7 @@ class BaseResponse(BaseModel):
 class AudioResponse(BaseResponse):
     """Response model for the ASR audio file and url endpoint."""
 
-    dual_channel: bool
+    multi_channel: bool
 
     class Config:
         """Pydantic config class."""
@@ -132,7 +132,7 @@ class AudioResponse(BaseResponse):
                     "diarization": None,
                     "post_processing": 0.239,
                 },
-                "dual_channel": False,
+                "multi_channel": False,
             }
         }
 
@@ -216,7 +216,7 @@ class CortexPayload(BaseModel):
     offset_end: Optional[float] = None
     num_speakers: Optional[int] = -1
     diarization: Optional[bool] = False
-    dual_channel: Optional[bool] = False
+    multi_channel: Optional[bool] = False
     source_lang: Optional[str] = "en"
     timestamps: Optional[Timestamps] = Timestamps.seconds
     vocab: Optional[List[str]] = []
@@ -242,7 +242,7 @@ class CortexPayload(BaseModel):
                 "offset_end": None,
                 "num_speakers": -1,
                 "diarization": False,
-                "dual_channel": False,
+                "multi_channel": False,
                 "source_lang": "en",
                 "timestamps": "s",
                 "vocab": [
@@ -313,7 +313,7 @@ class CortexUrlResponse(AudioResponse):
                     "diarization": None,
                     "post_processing": 0.239,
                 },
-                "dual_channel": False,
+                "multi_channel": False,
                 "job_name": "job_name",
                 "request_id": "request_id",
             }
@@ -435,7 +435,7 @@ class BaseRequest(BaseModel):
 class AudioRequest(BaseRequest):
     """Request model for the ASR audio file and url endpoint."""
 
-    dual_channel: bool = False
+    multi_channel: bool = False
 
     class Config:
         """Pydantic config class."""
@@ -460,7 +460,7 @@ class AudioRequest(BaseRequest):
                 "log_prob_threshold": -1.0,
                 "no_speech_threshold": 0.6,
                 "condition_on_previous_text": True,
-                "dual_channel": False,
+                "multi_channel": False,
             }
         }
 

--- a/src/wordcab_transcribe/router/v1/cortex_endpoint.py
+++ b/src/wordcab_transcribe/router/v1/cortex_endpoint.py
@@ -73,7 +73,7 @@ async def run_cortex(
                 offset_end=payload.offset_end,
                 num_speakers=payload.num_speakers,
                 diarization=payload.diarization,
-                dual_channel=payload.dual_channel,
+                multi_channel=payload.multi_channel,
                 source_lang=payload.source_lang,
                 timestamps=payload.timestamps,
                 vocab=payload.vocab,

--- a/src/wordcab_transcribe/router/v1/youtube_endpoint.py
+++ b/src/wordcab_transcribe/router/v1/youtube_endpoint.py
@@ -55,7 +55,7 @@ async def inference_with_youtube(
                 offset_end=data.offset_end,
                 num_speakers=data.num_speakers,
                 diarization=data.diarization,
-                dual_channel=False,
+                multi_channel=False,
                 source_lang=data.source_lang,
                 timestamps_format=data.timestamps,
                 vocab=data.vocab,

--- a/src/wordcab_transcribe/services/post_processing_service.py
+++ b/src/wordcab_transcribe/services/post_processing_service.py
@@ -20,7 +20,7 @@
 """Post-Processing Service for audio files."""
 
 import itertools
-from typing import Any, Dict, List, Union
+from typing import List, Union
 
 from wordcab_transcribe.utils import convert_timestamp, format_punct, is_empty_string
 
@@ -67,7 +67,7 @@ class PostProcessingService:
         self, multi_channel_segments: List[List[dict]]
     ) -> List[dict]:
         """
-        Run the dual channel post-processing functions on the inputs by merging the segments based on the timestamps.
+        Run the multi-channel post-processing functions on the inputs by merging the segments based on the timestamps.
 
         Args:
             multi_channel_segments (List[dict]): List of segments from both speakers.
@@ -313,26 +313,6 @@ class PostProcessingService:
             sentence["text"] = sentence["text"].strip()
 
         return sentences
-
-    def merge_segments(
-        self,
-        speaker_0_segments: List[Dict[str, Any]],
-        speaker_1_segments: List[Dict[str, Any]],
-    ) -> List[Dict[str, Any]]:
-        """
-        Merge two lists of segments, keeping the chronological order.
-
-        Args:
-            speaker_0_segments (List[Dict[str, Any]]): List of segments from speaker 0.
-            speaker_1_segments (List[Dict[str, Any]]): List of segments from speaker 1.
-
-        Returns:
-            List[Dict[str, Any]]: Merged list of segments.
-        """
-        merged_segments = speaker_0_segments + speaker_1_segments
-        merged_segments.sort(key=lambda seg: seg["start"])
-
-        return merged_segments
 
     def final_processing_before_returning(
         self,

--- a/src/wordcab_transcribe/services/vad_service.py
+++ b/src/wordcab_transcribe/services/vad_service.py
@@ -45,7 +45,7 @@ class VadService:
         self, waveform: torch.Tensor, group_timestamps: Optional[bool] = True
     ) -> Tuple[Union[List[dict], List[List[dict]]], torch.Tensor]:
         """
-        Use the VAD model to get the speech timestamps. Dual channel pipeline.
+        Use the VAD model to get the speech timestamps. Multi-channel pipeline.
 
         Args:
             waveform (torch.Tensor): Audio tensor.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -146,7 +146,7 @@ def test_audio_request() -> None:
     request = AudioRequest(
         num_speakers=-1,
         diarization=True,
-        dual_channel=True,
+        multi_channel=True,
         source_lang="en",
         timestamps="s",
     )
@@ -154,7 +154,7 @@ def test_audio_request() -> None:
     assert request.offset_end is None
     assert request.num_speakers == -1
     assert request.diarization is True
-    assert request.dual_channel is True
+    assert request.multi_channel is True
     assert request.source_lang == "en"
     assert request.timestamps == "s"
     assert request.vocab == []
@@ -176,7 +176,7 @@ def test_audio_response() -> None:
         offset_end=None,
         num_speakers=-1,
         diarization=False,
-        dual_channel=False,
+        multi_channel=False,
         source_lang="en",
         timestamps="s",
         vocab=["custom company", "custom product"],
@@ -200,7 +200,7 @@ def test_audio_response() -> None:
     assert response.offset_end is None
     assert response.num_speakers == -1
     assert response.diarization is False
-    assert response.dual_channel is False
+    assert response.multi_channel is False
     assert response.source_lang == "en"
     assert response.timestamps == "s"
     assert response.vocab == ["custom company", "custom product"]
@@ -240,7 +240,7 @@ def test_audio_response() -> None:
         offset_end=None,
         num_speakers=-1,
         diarization=True,
-        dual_channel=True,
+        multi_channel=True,
         source_lang="en",
         timestamps="s",
         vocab=["custom company", "custom product"],
@@ -279,7 +279,7 @@ def test_audio_response() -> None:
     assert response.offset_end is None
     assert response.num_speakers == -1
     assert response.diarization is True
-    assert response.dual_channel is True
+    assert response.multi_channel is True
     assert response.source_lang == "en"
     assert response.timestamps == "s"
     assert response.vocab == ["custom company", "custom product"]
@@ -431,7 +431,7 @@ def test_cortex_payload() -> None:
         offset_end=None,
         num_speakers=-1,
         diarization=False,
-        dual_channel=False,
+        multi_channel=False,
         source_lang="en",
         timestamps="s",
         word_timestamps=False,
@@ -447,7 +447,7 @@ def test_cortex_payload() -> None:
     assert payload.offset_end is None
     assert payload.num_speakers == -1
     assert payload.diarization is False
-    assert payload.dual_channel is False
+    assert payload.multi_channel is False
     assert payload.source_lang == "en"
     assert payload.timestamps == "s"
     assert payload.vocab == []
@@ -502,7 +502,7 @@ def test_cortex_url_response() -> None:
             diarization=2.0,
             post_processing=1.0,
         ),
-        dual_channel=False,
+        multi_channel=False,
         job_name="test_job",
         request_id="test_request_id",
     )
@@ -543,7 +543,7 @@ def test_cortex_url_response() -> None:
         diarization=2.0,
         post_processing=1.0,
     )
-    assert response.dual_channel is False
+    assert response.multi_channel is False
     assert response.job_name == "test_job"
     assert response.request_id == "test_request_id"
 


### PR DESCRIPTION
This PR updates the `dual_channel` process to make it functional with N audio channels.

* Renamed `dual_channel` to `multi_channel`.
* Simplified the audio pre-processing step based on the number of audio channels.
* Removed one old dual_channel method.