### PR TITLE
(Minor) Fixed typo in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt update && apt install -y \
 RUN apt update && apt install -y \
     libtiff-tools=4.3.0-6ubuntu0.8 \
     libtiff5=4.3.0-6ubuntu0.8 \
-    libgnutls30=3.7.3-4ubuntu1.4 \
+    libgnutls30=3.7.3-4ubuntu1.5 \
     openssl=3.0.2-0ubuntu1.15 \
     libpam-modules=1.4.0-11ubuntu2.4 \
     libpam-modules-bin=1.4.0-11ubuntu2.4 \


### PR DESCRIPTION
[[Issue 302](https://github.com/Wordcab/wordcab-transcribe/issues/302)] Fixed a typo for package version of `libgnutls30`.