### PR TITLE
install python dependencies on docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,12 @@ RUN curl -L ${RELEASE_URL} | tar -zx -C /tmp \
     && pip install /tmp/mpi4py-${MPI4PY_VERSION} \
     && rm -rf /tmp/mpi4py*
 
-RUN python -m pip install pip --upgrade \
-    && python -m pip install hatch
+RUN python -m pip install pip --upgrade
 
 WORKDIR /app
+
 COPY . .
 
-CMD ["hatch", "run", "runtime:launch"]
+RUN pip install --no-cache-dir --extra-index-url https://pypi.nvidia.com .[runtime]
+
+CMD ["uvicorn", "--host=0.0.0.0", "--port=5001", "src.wordcab_transcribe.main:app"]


### PR DESCRIPTION
There's no need to use Hatch inside the container. From what I understand, Hatch primarily focuses on isolating development environments (container its self provides isolation for application/process) and managing dependencies dynamically. With the container, all necessary dependencies are pre-installed, which means the main task is simply launching the application. Once launched, no additional work related to dependencies is required.

- remove hatch from docker image
- install python dependencies on docker image
- replace hatch run with raw cmd

close #297 