### PR TITLE
Update Dockerfile libtiff-tools libtiff5 versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     liblzma-dev \
     libsqlite3-dev \
-    libtiff-tools=4.3.0-6ubuntu0.8 \
-    libtiff5=4.3.0-6ubuntu0.8 \
+    libtiff-tools=4.3.0-6ubuntu0.9 \
+    libtiff5=4.3.0-6ubuntu0.9 \
     libgnutls30=3.7.3-4ubuntu1.5 \
     openssl=3.0.2-0ubuntu1.15 \
     libpam-modules=1.4.0-11ubuntu2.4 \


### PR DESCRIPTION
[libtiff-tools](https://www.ubuntuupdates.org/package/core/jammy/universe/security/libtiff-tools)
[libtiff5](https://www.ubuntuupdates.org/package/core/jammy/main/security/libtiff5)

Both packages have been updated to 0.9. The old 0.8 versions are no longer downloadable from apt