### PR TITLE
Fix outdated Dockerfile deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     liblzma-dev \
     libsqlite3-dev \
-    libtiff-tools=4.3.0-6ubuntu0.9 \
-    libtiff5=4.3.0-6ubuntu0.9 \
+    libtiff-tools=4.3.0-6ubuntu0.10 \
+    libtiff5=4.3.0-6ubuntu0.10 \
     libgnutls30=3.7.3-4ubuntu1.5 \
-    openssl=3.0.2-0ubuntu1.15 \
+    openssl=3.0.2-0ubuntu1.18 \
     libpam-modules=1.4.0-11ubuntu2.4 \
     libpam-modules-bin=1.4.0-11ubuntu2.4 \
     libpam-runtime=1.4.0-11ubuntu2.4 \


### PR DESCRIPTION
Fixes the following during docker build:

```
8.035 Package openssl is not available, but is referred to by another package.
8.035 This may mean that the package is missing, has been obsoleted, or
8.035 is only available from another source
8.035 
8.035 Package libtiff5 is not available, but is referred to by another package.
8.035 This may mean that the package is missing, has been obsoleted, or
8.035 is only available from another source
8.035 
8.035 Package libtiff-tools is not available, but is referred to by another package.
8.035 This may mean that the package is missing, has been obsoleted, or
8.035 is only available from another source
8.035 
8.038 E: Version '4.3.0-6ubuntu0.9' for 'libtiff-tools' was not found
8.038 E: Version '4.3.0-6ubuntu0.9' for 'libtiff5' was not found
8.038 E: Version '3.0.2-0ubuntu1.15' for 'openssl' was not found
```